### PR TITLE
feat: RAI v2.0.1 — token optimisation, loop detection, tool compaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ __pycache__/
 .tox/
 .coverage
 coverage.xml
+# JS/Node
+node_modules/
+dist/
+*.tsbuildinfo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,19 @@
 # RAI — Developer & Agent Guide
 
-> This file is the canonical reference for all AI agents and developers working on this project.
-> Claude Code users: `CLAUDE.md` routes here via `@AGENTS.md`.
+> Canonical reference for all AI agents and developers working on this project.
+> Claude Code: `CLAUDE.md` routes here via `@AGENTS.md`.
 
 ---
 
 ## Project Overview
 
-**revolt-rai** (`rai`) is an open-source AI security operator — a deployable agent system for penetration testing, red team operations, security research, and automated code analysis. It ships as a Python package with a CLI (`rai`), an HTTP harness (FastAPI), a Textual TUI, and a full SDK for embedding.
+**revolt-rai** (`rai`) is an open-source AI security operator — autonomous, adaptive, full-spectrum cybersecurity: threat modeling, SAST, pentesting, red team, bug bounty, VAPT, SOC.
 
-- **Python**: 3.11+
-- **Current version**: see `pyproject.toml`
+- **Python**: 3.11+ | **Current version**: `2.0.1` (see `pyproject.toml`)
 - **Core framework**: `deepagents==0.5.3` (pinned — do not upgrade without full regression)
 - **Agent graph**: LangGraph `CompiledStateGraph` + SQLite checkpointer (`~/.rai/sessions.db`)
 - **Model default**: `anthropic:claude-sonnet-4-6`
+- **JS SDK**: `@revolt-rai/js` v1.0.0 at `packages/rai-js/`
 
 ---
 
@@ -21,187 +21,171 @@
 
 ```
 rai/
-├── src/rai/                # Core package (all source lives here)
-│   ├── __init__.py         # Top-level exports: create_rai_agent, build_model
-│   ├── cli/                # CLI (main.py, serve.py, explorer.py, refs.py)
-│   ├── sdk/                # Public SDK surface (agent, builder, client, tui, etc.)
-│   ├── engine/             # Agent factory (factory.py) + model builder (model.py)
-│   ├── harness/            # FastAPI HTTP server + SSE + HITL + plan routes
-│   │   ├── app.py          # AgentPool + FastAPI app wiring
-│   │   ├── runner.py       # execute_run() coroutine, _RUN_REGISTRY, _HITL_FUTURES
-│   │   ├── sse.py          # RunEventBus + ThreadNotifBus
-│   │   ├── models.py       # Pydantic request/response models
-│   │   ├── selflearn.py    # Self-learning memory phase after runs
-│   │   ├── plan/           # Plan mode tools (write_plan, enter_step, etc.)
-│   │   ├── routes/         # FastAPI routers
-│   │   │   ├── agents.py       # /agents — registry, compile, model info
-│   │   │   ├── runs.py         # /runs — create, stream, cancel, approve
-│   │   │   ├── threads.py      # /threads — list, get, state, history, compact, inject
-│   │   │   ├── hitl.py         # /threads/{id}/interrupt — HITL interrupt handling
-│   │   │   ├── tasks.py        # /tasks — background task tracker
-│   │   │   ├── pipelines.py    # /pipelines — multi-agent pipeline execution
-│   │   │   ├── notifications.py# /notifications — server push
-│   │   │   ├── runtime.py      # /runtime — dynamic agent registration
-│   │   │   └── system.py       # /ok — health check
-│   │   └── subagents/      # Subagent HTTP execution layer
-│   ├── tui/                # Textual TUI
-│   │   ├── app.py          # RaiHttpTUIApp (2000 lines — main TUI)
-│   │   ├── runner.py       # TUI → server bridge
-│   │   ├── themes.py       # 4 themes: rai, github-dark, glass, claude
-│   │   ├── screens/        # Modal screens (runs, threads, theme, model, mcp)
-│   │   └── widgets/        # 15 custom widgets (see TUI section)
-│   ├── middleware/         # 15+ middleware modules (see Middleware Stack)
-│   ├── tools/              # 8 tool domains (see Tools section)
-│   ├── agents/             # AGENTS.md parser + subagent loader + background runner
-│   ├── skills/             # Skills discovery, invocation, CRUD
-│   ├── mcp/                # MCP tool loading, session manager, config discovery
-│   ├── sessions/           # Thread persistence (store.py — SQLite helpers)
-│   ├── config/             # RAISettings singleton + per-agent config.toml
-│   ├── data/               # Bundled prompts, skills, OPPLAN templates
-│   │   ├── prompts/        # rai/, recon/, researcher/, coder/, sast-analyzer/, agent-creator/
-│   │   └── skills/         # skill-creator/SKILL.md
-│   ├── client/             # HTTP client for RAI server (_sse.py, _events.py, etc.)
-│   ├── defaults/           # Default agent + skill seeding (agents.py, skills.py)
-│   ├── hooks/              # Claude Code PreToolUse/PostToolUse hooks
-│   └── update/             # Version check + upgrade helper
+├── src/rai/                    # Python core package
+│   ├── __init__.py             # version = 2.0.1, top-level exports
+│   ├── cli/                    # CLI (main.py, http_server.py, serve.py, explorer.py, refs.py)
+│   ├── sdk/                    # Public Python SDK surface
+│   ├── engine/                 # Agent factory (factory.py) + model builder (model.py)
+│   ├── harness/                # FastAPI HTTP server + SSE + HITL + plan routes
+│   │   ├── app.py              # AgentPool + FastAPI app wiring
+│   │   ├── runner.py           # execute_run() coroutine, _RUN_REGISTRY, _HITL_FUTURES
+│   │   ├── sse.py              # RunEventBus + ThreadNotifBus
+│   │   ├── models.py           # Pydantic request/response models
+│   │   ├── selflearn.py        # Self-learning memory phase after runs
+│   │   ├── plan/               # Plan mode tools (write_plan, enter_step, etc.)
+│   │   └── routes/             # FastAPI routers (agents, runs, threads, hitl, tasks, pipelines)
+│   ├── tui/                    # Textual TUI
+│   │   ├── app.py              # RaiHttpTUIApp (2000 lines)
+│   │   ├── history.py          # Persistent prompt history (~/.rai/history.jsonl)
+│   │   ├── themes.py           # 4 themes: rai, github-dark, glass, claude
+│   │   ├── screens/            # Modal screens (runs, threads, theme, model, mcp)
+│   │   └── widgets/            # 15 custom widgets
+│   ├── middleware/             # 19 middleware modules
+│   ├── tools/                  # 8 tool domains (core, security, web, cloud, ad, android, container, reversing)
+│   ├── agents/                 # AGENTS.md parser + subagent loader + background runner
+│   ├── sessions/               # Thread persistence (store.py — SQLite helpers)
+│   ├── config/                 # RAISettings singleton + per-agent config.toml
+│   └── data/                   # Bundled prompts, skills, OPPLAN templates
+│
+├── packages/
+│   └── rai-js/                 # TypeScript SDK (@revolt-rai/js v1.0.0)
+│       ├── src/
+│       │   ├── client.ts       # RAIClient — REST + SSE, getHeaders, dynamic auth
+│       │   ├── events.ts       # 40+ typed SSE event interfaces
+│       │   ├── subagents.ts    # SubagentManager class
+│       │   ├── useRAIStream.ts # React hook (useReducer-based, no stale closures)
+│       │   └── index.ts        # Public exports
+│       ├── examples/
+│       │   ├── chatbox/        # Full React chat app (Vite + Tailwind)
+│       │   └── patterns/       # 10 pattern files comparing RAI vs LangGraph SDK
+│       ├── package.json        # @revolt-rai/js, version 1.0.0
+│       └── README.md           # 848-line production docs
+│
+├── static/                     # Static assets (rai-logo.png) — copied into Docker
+├── docker/
+│   └── Dockerfile              # Multi-stage build, non-root rai user, port 8000
 ├── tests/
 │   └── test_agentic_loop.py
-├── examples/               # 12 runnable SDK examples
-├── pyproject.toml
-└── README.md
+├── examples/                   # 12 Python SDK examples
+├── .github/workflows/
+│   ├── publish-pypi.yml        # PyPI publish on GitHub Release
+│   ├── publish-npm.yml         # npm publish on GitHub Release / v* tag
+│   └── publish-docker-image.yml# GHCR publish on Release / tag / main push
+├── pyproject.toml              # revolt-rai 2.0.1, hatchling build
+├── AGENTS.md                   # This file
+├── CLAUDE.md                   # Routes to @AGENTS.md
+└── release.md                  # v2.0.0 release notes
 ```
 
 ---
 
-## Architecture: Agent Creation Pipeline
+## Critical Bug Fixes Applied (v2.0.1)
 
-All agent creation flows through `src/rai/engine/factory.py` → `create_rai_agent()`.
+All fixes are committed and verified. **Do not revert.**
 
-### What `create_rai_agent()` assembles
+### Original 9 critical fixes
 
-1. **Model** — via `build_model()` (LiteLLM resolver: prefix `anthropic:`, `openai:`, `google:`, etc.)
-2. **System prompt** — resolved in priority order:
-   - `~/.rai/agents/<name>/prompt.md` (user override)
-   - `src/rai/data/prompts/<name>/prompt.md` (bundled)
-   - Body of `~/.rai/agents/<name>/AGENTS.md` (agent creator flow)
-   - Slim subagent default (`data/prompts/subagent/prompt.md`)
-   - Full RAI prompt (`data/prompts/rai/prompt.md` — 14,500 tokens)
-3. **Tools** — loaded per domain (see Tools section)
-4. **Middleware stack** — 19 layers applied in fixed order (see Middleware section)
-5. **Subagents** — from `AGENTS.md` entries + `~/.rai/agents/<name>/subagents/*.toml`
-6. **Backend** — `CompositeBackend(LocalShellBackend, FilesystemBackend)`
-7. **Checkpointer** — `AsyncSqliteSaver` → `~/.rai/sessions.db`
+| # | File | Fix | Severity |
+|---|------|-----|----------|
+| 1 | `middleware/audit.py` | `await asyncio.to_thread()` — non-blocking audit log | Critical |
+| 2 | `harness/routes/hitl.py` | `_SESSION_APPROVED[thread_id]` — session approval actually works | Critical |
+| 3 | `harness/sse.py` | `RunEventBus.cleanup()` on shutdown — no memory leak | High |
+| 4 | `tools/core/memory.py` | `content_file` allowlist — path traversal blocked | Security |
+| 5 | `sessions/store.py` | `get_thread_by_id_sync()` — O(1) thread lookup | Performance |
+| 6 | `harness/routes/threads.py` | Correct agent graph used per thread | High |
+| 7 | `engine/factory.py` | Credentials bridged to env for `ConfigurableModelMiddleware` | Critical |
+| 8 | `engine/factory.py` | `setdefault` → `if not os.environ.get()` — empty env vars handled | Critical |
+| 9 | `cli/http_server.py` | `try/finally` + SIGTERM — server always stops cleanly | Critical |
 
-### SDK public surface (`src/rai/sdk/__init__.py`)
+**Build fix**: `pyproject.toml` — `src/rai/**` added to sdist `include`. The previous PyPI wheel was empty (just metadata). `pip install revolt-rai` now works.
 
-```python
-from rai.sdk import (
-    # High-level
-    RAIAgent, RAIAgentBuilder, RunableAgent,
-    # Serve
-    ServeConfig, serve_module,
-    # HTTP server
-    RAIHTTPServer, HTTPConfig,
-    # TUI
-    RaiHttpTUI, RaiHttpTUIApp,
-    # Client
-    RAIClient, ClientConfig,
-    # Engine
-    create_rai_agent, build_model, ModelConfig, run_agent,
-    # Config
-    settings, AgentConfig, load_agent_config,
-    # Middleware (all classes)
-    AuditLogMiddleware, HooksMiddleware, RTKToolMiddleware,
-    ExecuteInterceptorMiddleware, RateLimitMiddleware,
-    AskUserMiddleware, RAIMemoryMiddleware, SkillsMiddleware,
-    LocalContextMiddleware, SummarizationToolMiddleware,
-    RAIPromptCachingMiddleware, PlanModeMiddleware, OPPLANMiddleware,
-    FindingsEnrichmentMiddleware, MessageCompressionMiddleware,
-    # Tools getters
-    get_core_tools, get_security_tools, get_web_tools,
-    get_cloud_tools, get_ad_tools, get_android_tools,
-    get_container_tools, get_reversing_tools,
-    # MCP
-    load_mcp_tools, load_subagents_mcp_tools_map,
-    # Session
-    generate_thread_id, get_checkpointer, build_stream_config,
-    # Deepagents primitives
-    SubAgent, AsyncSubAgent, CompiledSubAgent,
-    # SSE event types (20+)
-    RunStartEvent, RunEndEvent, TokenEvent, ThinkingEvent,
-    ToolStartEvent, ToolEndEvent, InterruptEvent,
-    PlanModeEnteredEvent, PlanReadyEvent, StepStartEvent,
-    StepCompleteEvent, SubagentStartedEvent,
-)
-```
+### Post-v2.0.1 token optimisation fixes
+
+| # | File | Fix | Impact |
+|---|------|-----|--------|
+| 10 | `middleware/compression.py` | `_char_estimate()` now counts tool_call args — was only counting content, letting 120k chars bypass the 75k budget | Critical (caused 390-msg sessions at 119k chars) |
+| 11 | `engine/factory.py` | `TOOL_RESULT_TOKEN_LIMIT` 8000→4000 tokens — reduces LangGraph checkpoint bloat | High |
+| 12 | `engine/factory.py` | Summarization uses `cfg.compact_model` (cheap model) instead of main model | High ($2-5 saved per session) |
+| 13 | `harness/plan/tools.py` | `exit_plan_mode` result stripped full step digest (~5,700 chars saved per plan session) | Medium |
+| 14 | `harness/plan/tools.py` | `list_plan_steps` compact for done steps — strips description/how_to, keeps notes[:150] | Medium |
+| 15 | `tui/app.py` + `client/threads.py` | `history_tail()` — TUI now loads last 50 msgs not first 50 | UX |
+| 16 | `tui/app.py` | Filter `<system-reminder>` human messages from history display | UX |
 
 ---
 
-## Middleware Stack (execution order, outermost → innermost)
+## Middleware Stack (outermost → innermost, 22 layers)
 
 | # | Class | File | Role |
 |---|-------|------|------|
 | 1 | `ConfigurableModelMiddleware` | deepagents-cli | Per-request model override via runtime context |
-| 2 | `AuditLogMiddleware` | `middleware/audit.py` | Logs every tool call to `~/.rai/audit.log` (async) |
+| 2 | `AuditLogMiddleware` | `middleware/audit.py` | Async tool call logging to `~/.rai/audit.log` |
 | 3 | `HooksMiddleware` | `middleware/hooks.py` | Claude Code PreToolUse/PostToolUse hooks |
+| 3.5 | `LoopDetectionMiddleware` | `middleware/loop_detection.py` | **NEW** Blocks duplicate tool calls — returns cached result with ⚠ warning when agent re-issues identical bash/grep/read. Stops degenerate 50× loops under context pressure |
 | 4 | `RTKToolMiddleware` | `middleware/rtk.py` | Rewrites bash commands via `rtk rewrite` |
-| 5 | `ExecuteInterceptorMiddleware` | `middleware/execute.py` | Routes `execute` → RAI BashTool |
-| 6 | `RateLimitMiddleware` | `middleware/ratelimit.py` | Per-tool delay (profile: aggressive/normal/stealth) |
-| 7 | `AskUserMiddleware` | deepagents-cli | Injects `ask_user` tool for HITL questions |
+| 5 | `ExecuteInterceptorMiddleware` | `middleware/execute.py` | Routes execute → RAI BashTool |
+| 6 | `RateLimitMiddleware` | `middleware/ratelimit.py` | Per-tool delays (profile: aggressive/normal/stealth) |
+| 7 | `AskUserMiddleware` | deepagents-cli | Injects ask_user tool |
 | 8 | `RAIMemoryMiddleware` | `middleware/memory.py` | Inlines ≤4k files, indexes large ones |
-| 9 | `SkillsMiddleware` | `middleware/skills.py` (via deepagents-cli) | Loads skills from 6 directories |
-| 10 | `LocalContextMiddleware` | deepagents-cli | Security-aware environment detection |
+| 9 | `SkillsMiddleware` | deepagents-cli | Loads skills from 6 dirs |
+| 10 | `LocalContextMiddleware` | deepagents-cli | Security-aware env detection |
 | 11 | `StaticSystemPromptCacheBreakpointMiddleware` | `middleware/cache_split.py` | Splits static/dynamic for Anthropic prompt caching |
-| 12 | `FindingsEnrichmentMiddleware` | `middleware/findings.py` | Keeps findings count visible in system prompt |
-| 13 | `OPPLANMiddleware` OR `PlanModeMiddleware` | `middleware/opplan.py` / `middleware/plan_mode.py` | OPPLAN (CLI) or HTTP plan mode |
+| 12 | `FindingsEnrichmentMiddleware` | `middleware/findings.py` | Findings count in system prompt |
+| 13 | `OPPLANMiddleware` OR `PlanModeMiddleware` | `middleware/opplan.py` / `plan_mode.py` | OPPLAN (CLI) or HTTP plan mode |
 | 14 | `ModelOverrideMiddleware` | `middleware/model_override.py` | Per-call model switching via env var |
-| 15 | `MessageCompressionMiddleware` | `middleware/compression.py` | Trims history to ~30k tokens |
-| 16 | `SummarizationToolMiddleware` | `middleware/summarization.py` | Auto-compact + manual `/compact` |
-| 17 | `RAIPromptCachingMiddleware` | `middleware/prompt_cache.py` | Anthropic prompt caching with LiteLLM support |
-| 18 | `ModelCallLoggerMiddleware` | `middleware/model_logger.py` | Debug logging (`RAI_DEBUG_LOG_CALLS=1`) |
+| 15 | `MessageCompressionMiddleware` | `middleware/compression.py` | **Layer 1 compression** — trim all history to ≤30k tokens. Zero LLM cost |
+| 15.7 | `ToolResultCompressionMiddleware` | `middleware/tool_compaction.py` | **Layer 2 compression** — truncate old bash/file/http results (>500 chars → 1500 max) + old bash args (>600 chars). Never touches: HumanMessage, plan tools, findings, memory, ask_user, last 20 messages. Saves 60-80% tokens on long sessions |
+| 16 | `SummarizationToolMiddleware` | `middleware/summarization.py` | **Layer 3 compression** — LLM summarization at 100k tokens or 40 messages. Exposes `/compact` command |
+| 17 | `RAIPromptCachingMiddleware` | `middleware/prompt_cache.py` | Anthropic prompt caching (also works via LiteLLM proxy) |
+| 18 | `ModelCallLoggerMiddleware` | `middleware/model_logger.py` | Debug logging when `RAI_DEBUG_LOG_CALLS=1` — logs effective_count, total_chars, estimated_tokens, truncated_count |
 | 19 | `EmptyContentSanitizerMiddleware` | `middleware/sanitizer.py` | Strips empty text blocks (Bedrock compatibility) |
-
-**Rule**: When adding a new middleware, insert it at the correct logical position — do not append. Audit and hooks always come before tool execution layers.
 
 ---
 
-## Tools
-
-Tool result token limit: `TOOL_RESULT_TOKEN_LIMIT = 8000` (overrides deepagents default of 20000).
-
-### Domain → Getter → Tools
+## Tools (8 domains)
 
 | Domain | Getter | Key tools |
 |--------|--------|-----------|
 | Core | `get_core_tools()` | `bash`, `findings`, `memory`, `opplan`, `references` |
-| Security | `get_security_tools()` | `http_request`, `nuclei_scan`, `nmap_scan`, `web_search`, `web_fetch`, `create_subagent` |
-| Web | `get_web_tools()` | `jwt_decode`, `jwt_forge`, `jwt_crack`, `oauth_audit`, `graphql_introspect` |
-| Cloud | `get_cloud_tools()` | `aws_cli`, `gcp_cli`, `az_cli`, `kubectl`, `k8s_audit`, `terraform_scan` |
-| Container | `get_container_tools()` | `docker_audit`, `docker_escape_check`, `docker_image_scan`, `k8s_pod_escape` |
-| Active Directory | `get_ad_tools()` | `bloodhound_collect`, `kerberoast`, `asreproast`, `dcsync`, `adcs_audit`, `ldap_enum` |
-| Android | `get_android_tools()` | `apk_info`, `apk_decompile`, `android_manifest_audit`, `adb_shell`, `frida_inject` |
-| Reversing | `get_reversing_tools()` | `binary_info`, `strings_extract`, `symbols_extract`, `packer_detect`, `rop_gadgets`, `disassemble` |
+| Security | `get_security_tools()` | `http_request`, `nuclei_scan`, `nmap_scan`, `web_search`, `create_subagent` |
+| Web | `get_web_tools()` | `jwt_decode`, `jwt_forge`, `oauth_audit`, `graphql_introspect` |
+| Cloud | `get_cloud_tools()` | `aws_cli`, `gcp_cli`, `az_cli`, `kubectl`, `terraform_scan` |
+| Container | `get_container_tools()` | `docker_audit`, `docker_escape_check`, `k8s_pod_escape` |
+| AD | `get_ad_tools()` | `bloodhound_collect`, `kerberoast`, `dcsync`, `ldap_enum` |
+| Android | `get_android_tools()` | `apk_decompile`, `android_manifest_audit`, `frida_inject` |
+| Reversing | `get_reversing_tools()` | `binary_info`, `rop_gadgets`, `disassemble` |
 
-### Adding a new tool
+---
 
-1. Create `src/rai/tools/<domain>/my_tool.py` inheriting `BaseTool` (LangChain).
-2. Implement `_run()` (sync) and `_arun()` (async) — both required.
-3. Export from `src/rai/tools/<domain>/__init__.py` and add to the domain getter in `engine/factory.py`.
-4. Add to `sdk/__init__.py` exports if it should be public API.
+## HTTP API
 
-```python
-from langchain.tools import BaseTool
+Server default: `http://127.0.0.1:8000`
 
-class MyTool(BaseTool):
-    name: str = "my_tool"
-    description: str = "One-line description for the LLM."
-
-    def _run(self, arg: str) -> str:
-        ...
-
-    async def _arun(self, arg: str) -> str:
-        ...
 ```
+GET  /ok                                    Health check
+GET  /agents                                List registered agents
+
+POST /agents/{name}/runs                    Create run (returns run_id)
+GET  /agents/{name}/runs/{id}/stream        SSE stream of run events
+POST /agents/{name}/runs/{id}/cancel        Cancel run
+POST /agents/{name}/runs/{id}/plan/approve  Approve plan
+POST /agents/{name}/runs/{id}/plan/reject   Reject plan
+
+GET  /threads                               List threads
+GET  /threads/{id}/history                  Paginated message history (offset+limit)
+DELETE /threads/{id}                        Delete thread
+POST /threads/{id}/interrupt                Submit HITL decision
+POST /threads/{id}/ask_user                 Submit ask_user answers
+
+GET  /tasks                                 Background tasks
+POST /subagents/{id}/interrupt              Subagent HITL
+```
+
+### SSE events (40+ total, key ones)
+
+`run_start` → `token` → `thinking` → `tool_start` → `tool_end` → `interrupt` →
+`session_approved` → `ask_user_request` → `plan_mode_entered` → `plan_ready` →
+`step_start` → `step_complete` → `plan_completed` → `subagent_started` →
+`subagent_token` → `subagent_completed` → `run_end`
 
 ---
 
@@ -209,528 +193,274 @@ class MyTool(BaseTool):
 
 ```
 ~/.rai/
-├── agents/<name>/
-│   ├── config.toml          # Model, api_key, base_url, temperature, max_tokens, rate_limit_profile
-│   ├── AGENTS.md            # Subagent definitions for this agent (see format below)
-│   ├── prompt.md            # System prompt override (takes priority over bundled prompts)
-│   ├── mcp.json             # Per-agent MCP servers
-│   ├── memory/
-│   │   ├── user.md          # What the agent knows about the user
-│   │   ├── feedback.md      # Behavioral feedback
-│   │   ├── engagement.md    # Current engagement context
-│   │   ├── target.md        # Target scope notes
-│   │   ├── findings.md      # Persistent findings
-│   │   └── methodology.md   # Attack/analysis methodology
-│   └── skills/              # Agent-local skills
-├── user/
-│   ├── MEMORY.md            # User profile index
-│   ├── profile.md
-│   ├── preferences.md
-│   └── context.md
-├── targets/<target>/        # Per-target memory
-├── skills/                  # Global user skills
+├── agents/{name}/
+│   ├── config.toml          # model, api_key, base_url, temperature, max_tokens
+│   ├── AGENTS.md            # Subagent definitions (YAML frontmatter + system prompt)
+│   ├── prompt.md            # System prompt override (highest priority)
+│   └── memory/              # user.md, feedback.md, engagement.md, findings.md
 ├── .mcp.json                # Global MCP servers
-├── hooks.json               # Claude Code hooks
-├── audit.log                # All tool calls (JSON lines, rotated)
+├── audit.log                # All tool calls (JSON lines)
+├── history.jsonl            # TUI prompt history (1000 entries max)
 └── sessions.db              # LangGraph SQLite checkpointer
 ```
 
 ### config.toml format
 
 ```toml
-model = "anthropic:claude-sonnet-4-6"
-api_key = "sk-ant-..."       # or "" to use ANTHROPIC_API_KEY env var
-base_url = ""                # for custom endpoints / LiteLLM proxies
+model = "litellm:openai/bedrock-claude-sonnet-4.6-(US)"
+api_key = "sk-..."
+base_url = "https://llmproxy.example.com"
 temperature = 0.7
 max_tokens = 8192
 rate_limit_profile = "normal"  # aggressive | normal | stealth
+
+# Optional: cheaper model for context summarization (empty = inherit main model)
+# Set via: rai agents config-set --compact-model "litellm:openai/bedrock-claude-haiku-4.5-(US)"
+compact_model = ""           # empty = use same model as above
+compact_api_key = ""         # empty = inherit api_key
+compact_base_url = ""        # empty = inherit base_url
 ```
 
 ---
 
-## AGENTS.md Format (for defining subagents)
-
-Both the global `~/.rai/agents/<name>/AGENTS.md` and per-project `AGENTS.md` use the same format.
+## AGENTS.md Format (subagent definitions)
 
 ```markdown
 ---
 name: recon
-description: Network reconnaissance and asset discovery specialist
-model: anthropic:claude-sonnet-4-6
+description: Network reconnaissance and asset discovery
+model: inherit
 api_key: inherit
 base_url: inherit
 ---
 
-You are a reconnaissance specialist. Your goal is to map attack surfaces...
-
----
-name: coder
-description: Secure code analysis and development assistant
-model: inherit
----
-
-You are an expert software engineer with a focus on security...
+You are a reconnaissance specialist…
 ```
-
-**Frontmatter fields:**
-
-| Field | Required | Notes |
-|-------|----------|-------|
-| `name` | Yes | Agent identifier, used in CLI and API |
-| `description` | Yes | Shown in `rai agents list` |
-| `model` | No | LiteLLM model string; `"inherit"` = use parent's model |
-| `api_key` | No | `"inherit"` = use parent's api_key |
-| `base_url` | No | `"inherit"` = use parent's base_url |
-| `skills` | No | List of skill paths to enable |
-
-**Body**: Becomes the system prompt for this subagent. If empty, the bundled `data/prompts/<name>/prompt.md` is used if it exists, otherwise the slim subagent default.
-
----
-
-## HTTP Server API
-
-Server starts on `http://127.0.0.1:8000` by default (`rai chat` or `rai http serve`).
-
-### Key endpoints
-
-```
-GET  /ok                                    Health check
-GET  /agents                                List registered agents
-GET  /agents/{name}/model                   Agent model info
-
-POST /runs/{agent}                          Create a new run (returns run_id)
-GET  /runs/{agent}/{run_id}/stream          SSE stream of run events
-POST /runs/{agent}/{run_id}/cancel          Cancel a running run
-POST /runs/{agent}/{run_id}/plan/approve    Approve a plan in plan mode
-
-GET  /threads                               List threads
-GET  /threads/{id}                          Get thread metadata
-GET  /threads/{id}/state                    Current LangGraph state (messages, tasks, etc.)
-GET  /threads/{id}/history                  Paginated message history
-DELETE /threads/{id}                        Delete thread + all checkpoints
-GET  /threads/{id}/compact/status           Token usage estimate
-POST /threads/{id}/compact                  Trigger manual compaction
-GET  /threads/{id}/summary                  Latest summarization text
-POST /threads/{id}/messages                 Inject a HumanMessage (does not start execution)
-
-GET  /threads/{id}/interrupt                Check if HITL interrupt is pending
-POST /threads/{id}/interrupt                Submit HITL decision (approve/reject/edit/respond)
-GET  /threads/{id}/interrupt/stream         SSE stream of interrupt events for this thread
-POST /threads/{id}/ask_user                 Submit ask_user answers
-
-GET  /tasks                                 List background tasks
-GET  /tasks/{id}                            Background task status
-
-POST /pipelines                             Launch multi-agent pipeline
-```
-
-### SSE event types (from `RunEventBus`)
-
-All events carry `run_id`. Key events:
-
-| Event | Fields | Description |
-|-------|--------|-------------|
-| `run_start` | `agent`, `thread_id` | Run started |
-| `token` | `content` | LLM token stream |
-| `thinking` | `content` | Extended thinking block |
-| `tool_start` | `tool`, `args`, `tool_call_id` | Tool invocation started |
-| `tool_end` | `tool`, `result`, `tool_call_id` | Tool returned |
-| `interrupt` | `interrupt_id`, `action_requests` | HITL pause |
-| `plan_mode_entered` | — | Agent entered plan mode |
-| `plan_ready` | `plan` | Plan written, awaiting approval |
-| `step_start` | `step_index`, `step` | Plan step starting |
-| `step_complete` | `step_index` | Plan step done |
-| `subagent_started` | `subagent`, `task` | Subagent dispatched |
-| `run_end` | `status`, `message_count` | Run finished |
-| `error` | `detail` | Run errored |
-
-Reconnect with `Last-Event-ID` header — the bus replays up to 500 buffered frames.
-
----
-
-## TUI (`src/rai/tui/`)
-
-`RaiHttpTUIApp` is fully HTTP-connected — it does **not** inherit from deepagents or run a graph directly.
-
-### Widgets
-
-| Widget | File | Purpose |
-|--------|------|---------|
-| `MessagesWidget` | `widgets/messages.py` | Chat history + tool cards |
-| `ChatInput` | `widgets/chat_input.py` | Input box + slash commands |
-| `PlanPanel` | `widgets/plan_panel.py` | Plan display + step approval |
-| `HITLPanel` | `widgets/hitl_panel.py` | HITL interrupt UI |
-| `SubagentTree` | `widgets/subagent_tree.py` | Active subagent tree |
-| `FindingsPanel` | `widgets/findings_panel.py` | Live findings sidebar |
-| `StatusBar` | `widgets/status_bar.py` | Model/agent/thread status |
-| `BgPanel` | `widgets/bg_panel.py` | Background runs panel |
-| `ApprovalWidget` | `widgets/approval.py` | Tool approval cards |
-| `AskUserPanel` | `widgets/ask_user_panel.py` | ask_user question UI |
-| `WelcomeWidget` | `widgets/welcome.py` | Welcome screen |
-| `WizardStep` | `widgets/wizard_step.py` | Setup wizard step |
-
-### Slash commands (from `ChatInput`)
-
-`/new`, `/threads`, `/compact`, `/model`, `/mcp`, `/skills`, `/findings`, `/create-agent`, `/plan`, `/target`, `/memory`, `/clear`, and more.
-
-### Textual markup escaping — CRITICAL
-
-**Always** use the project's `_escape()` helper (full bracket replacement) for any user-supplied or agent-supplied text rendered in Textual widgets. **Never** use `rich.markup.escape()` — it misses edge cases that crash the markup parser.
-
-```python
-# Correct
-from rai.tui.widgets.messages import _escape
-widget.update(_escape(untrusted_text))
-
-# Wrong — do not use
-from rich.markup import escape
-widget.update(escape(untrusted_text))
-```
-
-### Keyboard shortcuts
-
-`ctrl+b` (background runs), `ctrl+n` (new thread), `ctrl+t` (thread browser), `ctrl+p` (plan panel), `ctrl+a` (approve all), `ctrl+f` (findings), `ctrl+m` (model picker), `ctrl+c` (cancel), `escape` (close modal).
-
----
-
-## CLI Commands
-
-Entry point: `rai` (Typer app in `cli/main.py`)
-
-```
-rai chat            Interactive TUI (local server by default; remote via --remote-url)
-rai run             Headless single-task execution
-rai serve           LangGraph API server (port 2024, hot reload, Studio integration)
-rai chat --remote-url <url> --server-key <key>   Connect TUI to an existing remote RAI HTTP server
-
-rai agents list           List all agents
-rai agents show <name>    Show agent config + prompt
-rai agents config <name>  Edit agent config.toml
-rai agents reset <name>   Reset to defaults
-
-rai config show     Show global config
-rai config init     Interactive setup wizard
-
-rai mcp add         Add MCP server (global or per-agent)
-rai mcp remove      Remove MCP server
-rai mcp list        List all MCP servers
-rai mcp get         Get server details
-
-rai skills list     List all skills
-rai skills create   Create new skill
-rai skills add      Add skill from git repo
-rai skills delete   Delete skill
-
-rai threads list    List recent threads
-rai threads delete  Delete a thread
-
-rai refs            Reference repository management
-rai version         Show version
-rai update          Check for and install updates
-rai http            HTTP client subcommands
-```
-
-**Global options**: `--model/-m`, `--agent/-a`, `--target/-t`, `--api-key`, `--base-url`, `--yes/-y`, `--rate-limit`, `--no-mcp`, `--no-rtk`, `--verbose/-v`
-
----
-
-## Sessions & Thread Persistence
-
-All thread state is persisted via LangGraph's `AsyncSqliteSaver` to `~/.rai/sessions.db`.
-
-Every stream config embeds metadata: `agent_name`, `cwd`, `git_branch`, `updated_at`. These are stored in the `checkpoints.metadata` JSON column and are queryable without deserializing checkpoint blobs.
-
-```python
-from rai.sessions.store import build_stream_config, generate_thread_id
-
-thread_id = generate_thread_id()  # UUID7 — time-ordered
-config = build_stream_config(thread_id, agent_name="rai", cwd=str(Path.cwd()))
-```
-
-Key sync helpers (used from HTTP routes, which run in sync context):
-- `list_threads_sync(agent_name, limit, sort_by)` — paginated list
-- `get_thread_by_id_sync(thread_id)` — O(1) direct lookup by ID
-- `thread_exists_sync(thread_id)` — boolean check
-- `delete_thread_sync(thread_id)` — cascades to `writes` table
 
 ---
 
 ## Plan Mode
 
-Plan mode is a structured multi-step approval gate built into `src/rai/harness/plan/tools.py` and `src/rai/middleware/plan_mode.py`.
+Structured multi-step execution with approval gate.
 
-### Flow
+1. Agent calls `enter_plan_mode()` → `plan_mode_entered` SSE
+2. Agent calls `write_plan(steps=[...])` → `plan_ready` SSE
+3. User approves: `POST /agents/{name}/runs/{id}/plan/approve`
+4. Agent iterates: `enter_step(n)` → work → `mark_step_done(n)`
+5. `exit_plan_mode()` → optional self-learning phase
 
-1. Agent calls `enter_plan_mode()` → state transitions to `plan_mode`
-2. Agent calls `write_plan(steps=[...])` → server emits `plan_ready` SSE event
-3. TUI shows plan; user approves/rejects/edits
-4. HTTP `POST /runs/{agent}/{run_id}/plan/approve` unblocks execution
-5. Agent iterates: `enter_step(n)` → do work → `mark_step_done(n)` or `mark_step_blocked(n, reason)`
-6. `exit_plan_mode()` → optional self-learning memory phase (runs `selflearn.py`)
+**Rule**: `_PLAN_FUTURES` is only set when `plan_ready` fires. Calling approve before that returns 409.
 
-Plan tools suppressed during step execution to prevent re-entry: `_PLAN_EXEC_TOOLS = {"enter_plan_mode", "write_plan"}`.
-
----
-
-## Memory Tool Security
-
-`memory_write` with `content_file` parameter is restricted to safe directories only:
-
-```
-/tmp/
-$TMPDIR/
-~/.rai/
-```
-
-Any `content_file` path outside these prefixes returns an error. This prevents path traversal / exfiltration of system files into persistent agent memory. See `src/rai/tools/core/memory.py`.
+Plan exec tools suppressed from UI: `enter_plan_mode`, `enter_step`, `mark_step_done`, `mark_step_blocked`, `exit_plan_mode`, `list_plan_steps`
 
 ---
 
-## Skills
+## JS SDK — @revolt-rai/js
 
-Skills are reusable prompt segments that augment agent capability without modifying the system prompt permanently.
+Located at `packages/rai-js/`. Published separately as `@revolt-rai/js v1.0.0`.
 
-### SKILL.md format
+### Architecture
 
-```markdown
----
-name: web-recon
-description: Web reconnaissance skill
-allowed_tools:
-  - bash
-  - http_request
-  - web_fetch
----
+- `useRAIStream` — `useReducer`-based React hook (no `useSyncExternalStore`, no stale closures)
+- `RAIClient` — fetch-based REST + SSE client with `getHeaders` async resolver
+- `SubagentManager` — stable class instance, signals React via `SUBAGENT_TICK` action
+- `dispatchRef` / `processEventRef` / `stateRef` — refs ensure async SSE loop always has latest functions
 
-You have been activated with the web-recon skill. Focus on...
+### Key methods
+
+```ts
+stream.submit(text, opts?)           // start run
+stream.stop()                        // abort SSE + cancel server run
+stream.disconnect()                  // abort SSE only — server keeps running
+stream.joinStream(runId, lastId?)    // reconnect to existing run
+stream.switchThread(id | null)       // switch thread (auto-loads history)
+stream.approveInterrupt()            // HITL approve
+stream.approveInterruptForSession()  // HITL approve for session
+stream.rejectInterrupt(msg?)
+stream.editInterrupt({ name, args })
+stream.respondToInterrupt(msg)
+stream.approvePlan()
+stream.rejectPlan(feedback?)
+stream.answerAskUser(answers)
 ```
 
-### Discovery sources (priority order)
+### Dynamic auth (getHeaders)
 
-1. Bundled (`src/rai/data/skills/`)
-2. Global user (`~/.rai/skills/`)
-3. Per-agent (`~/.rai/agents/<name>/skills/`)
-4. Project (`./.rai/skills/`)
-5. Claude user skills (`~/.claude/skills/`)
-6. Claude project skills (`.claude/skills/`)
-
-### Invocation
-
-Prefix in message: `/skill:web-recon` — the middleware injects the skill's prompt segment and restricts tool use to `allowed_tools`.
-
----
-
-## MCP Integration
-
-MCP servers are loaded per-agent at startup. Config discovery merges:
-1. `~/.rai/.mcp.json` (global)
-2. `~/.rai/agents/<name>/mcp.json` (per-agent)
-3. `./.mcp.json` (project-local)
-
-```json
-{
-  "mcpServers": {
-    "my-server": {
-      "command": "npx",
-      "args": ["@modelcontextprotocol/server-filesystem"],
-      "transport": "stdio",
-      "env": {}
-    }
-  }
-}
+```ts
+useRAIStream({
+  getHeaders: async () => ({
+    Authorization: `Bearer ${await auth.getToken()}`,
+    "X-MFA-Token": sessionStorage.getItem("mfa"),
+    "X-Org-Id": store.org.id,
+  }),
+});
 ```
 
-Transports supported: `stdio`, `sse`, `streamable-http`. SSL: auto-retry with `verify=False` for self-signed certs (with warning logged).
+Called before EVERY request including SSE reconnects, HITL decisions, plan approvals.
 
----
+### submit() options
 
-## Default Agents
-
-Seeded on first run from `src/rai/defaults/agents.py`. Main agent (`rai`) gets config only — always uses the bundled `data/prompts/rai/prompt.md`.
-
-| Agent | Purpose | Default model |
-|-------|---------|---------------|
-| `rai` | Main security operator | `anthropic:claude-sonnet-4-6` |
-| `recon` | Network/asset reconnaissance | inherit |
-| `researcher` | OSINT, threat intelligence | inherit |
-| `coder` | Secure code analysis + dev | inherit |
-| `sast-analyzer` | Static code analysis | inherit |
-| `agent-creator` | Creates new agents interactively | inherit |
-
----
-
-## Environment Variables
-
-| Variable | Effect |
-|----------|--------|
-| `ANTHROPIC_API_KEY` | Default API key for Anthropic models |
-| `OPENAI_API_KEY` | Default API key for OpenAI models |
-| `RAI_DEBUG_LOG_CALLS` | `1` → enable `ModelCallLoggerMiddleware` |
-| `RAI_AUDIT_LOG` | Override audit log path (default: `~/.rai/audit.log`) |
-| `RAI_DB_PATH` | Override sessions DB path (default: `~/.rai/sessions.db`) |
-| `RAI_RATE_LIMIT_PROFILE` | `aggressive` / `normal` / `stealth` |
-
----
-
-## Testing
-
-```bash
-pytest tests/
-pytest tests/test_agentic_loop.py -v
+```ts
+stream.submit(text, {
+  agent: "recon",
+  model: "anthropic:claude-opus-4-8",
+  planMode: true,
+  allowedTools: ["bash", "read_file"],
+  maxTurns: 30,
+  metadata: { user_id, org_id },
+  config: { target_scope: "*.example.com" },
+});
 ```
-
-Single test file currently: `tests/test_agentic_loop.py` (core agent loop tests).
-
-When writing new tests:
-- Do not mock the database; use a real SQLite checkpointer with a temp path.
-- Use `create_rai_agent()` factory — do not construct middleware manually.
-- Async tests: `pytest-asyncio` with `@pytest.mark.asyncio`.
-
----
-
-## Coding Conventions
-
-- **Python 3.11+**: use `from __future__ import annotations`, `X | Y` union types, `TypedDict`, `NotRequired`.
-- **No docstrings** on obvious functions. One short line only when the WHY is non-obvious.
-- **No comments** narrating what code does — names convey that.
-- **No unused abstractions** — add only what the task requires.
-- **Async I/O**: any blocking I/O in an async context must use `await asyncio.to_thread(fn, *args)`. Never call `open()`, `subprocess.run()` (blocking), or `time.sleep()` directly in an `async` function.
-- **Textual widgets**: always escape user/agent content with `_escape()` (see TUI section).
-- **Security**: never introduce new `content_file`-style parameters that read arbitrary paths. All file reads in tools must validate against an allowlist.
-- **Commit policy**: never commit unless the user explicitly asks. Never add `Co-Authored-By` or AI attribution to commit messages.
 
 ---
 
 ## Adding New Features — File Checklists
 
-Every change type has a fixed set of files that must all be updated together. Missing any one causes silent failures (tool not loaded, SDK symbol missing, agent not seeded, etc.).
+### New tool
+
+1. `src/rai/tools/{domain}/my_tool.py` — `BaseTool` subclass, `_run()` + `_arun()`
+2. `src/rai/tools/{domain}/__init__.py` — export the class
+3. `src/rai/engine/factory.py` — add to domain getter + `create_rai_agent()` tools list
+4. `src/rai/sdk/__init__.py` — export if public
+5. `AGENTS.md` — add to Tools table
+
+### New middleware
+
+1. `src/rai/middleware/my_middleware.py` — `AgentMiddleware` subclass (NOT `MiddlewareBase` — use `langchain.agents.middleware.types.AgentMiddleware`). Implement `wrap_tool_call` / `awrap_tool_call` for tool interception OR `wrap_model_call` / `awrap_model_call` for model call interception. Always fail-open.
+2. `src/rai/middleware/__init__.py` — add import + add to `__all__`
+3. `src/rai/engine/factory.py` — `agent_middleware.append(MyMiddleware())` at correct position (see stack table). Use lazy import inside factory function.
+4. `src/rai/sdk/middleware/middleware.py` — add import + add to `__all__`
+5. `src/rai/sdk/middleware/__init__.py` — add to imports from `.middleware` + add to `__all__`
+6. `src/rai/sdk/__init__.py` — add to `from rai.sdk.middleware import (...)` + add to `__all__`
+7. `AGENTS.md` — add row to Middleware Stack table with correct position number, file, and role
+8. Add env vars to Environment Variables table if tunable
+
+**Return type for tool middleware**: `ToolMessage` (from `langchain_core.messages`). See `loop_detection.py` for the exact pattern.
+**Return type for model middleware**: pass through via `handler(request)` or `request.override(messages=...)`. See `compression.py`.
+
+### New HTTP route
+
+1. `src/rai/harness/routes/my_route.py` — `APIRouter`
+2. `src/rai/harness/models.py` — request/response Pydantic models
+3. `src/rai/harness/app.py` — include router
+4. `src/rai/client/` — add client method
+5. `src/rai/sdk/__init__.py` — export
+6. `AGENTS.md` — add to HTTP API table
+
+### New SSE event
+
+1. `src/rai/harness/runner.py` — `await bus.publish("my_event", {...})`
+2. `src/rai/client/_events.py` — dataclass
+3. `src/rai/client/_sse.py` — dispatcher branch
+4. `packages/rai-js/src/events.ts` — TypeScript interface + add to RAIEvent union
+5. `packages/rai-js/src/useRAIStream.ts` — handle in `processEventRef.current` switch
+6. `src/rai/sdk/__init__.py` — export Python class
+7. `packages/rai-js/src/index.ts` — export TS type
+8. `AGENTS.md` — add to SSE events list
+
+### New JS SDK feature
+
+1. `packages/rai-js/src/` — implement
+2. `packages/rai-js/src/index.ts` — export
+3. `packages/rai-js/README.md` — document
+4. `packages/rai-js/examples/patterns/` — add example file
+5. `AGENTS.md` — update JS SDK section
 
 ---
 
-### Adding a new tool
+## Debug Tools
 
-| # | File | What to do |
-|---|------|-----------|
-| 1 | `src/rai/tools/<domain>/my_tool.py` | Create tool class inheriting `BaseTool`. Implement `_run()` and `_arun()`. |
-| 2 | `src/rai/tools/<domain>/__init__.py` | Export the class: `from .my_tool import MyTool` |
-| 3 | `src/rai/engine/factory.py` | Add `MyTool()` to the relevant domain getter (e.g. `get_security_tools()`) and include the getter's output in the `tools=[...]` list inside `create_rai_agent()` |
-| 4 | `src/rai/sdk/__init__.py` | Export `MyTool` and/or the getter in `__all__` if it should be part of the public SDK surface |
-| 5 | `AGENTS.md` (this file) | Add row to the Tools domain table |
+### Request Inspector (MITM proxy + request logging)
+**File**: `src/rai/middleware/request_inspector.py`
 
-**Adding a new domain** (e.g. `iot`): also create `src/rai/tools/iot/__init__.py`, add `get_iot_tools()` getter to `engine/factory.py`, and add the `sdk` export.
+Completely inert in production. Activate for debugging only:
+```bash
+# Log all LLM requests to ~/.rai/debug/requests.jsonl
+RAI_INSPECT=1 rai chat
 
----
-
-### Adding a new middleware
-
-| # | File | What to do |
-|---|------|-----------|
-| 1 | `src/rai/middleware/my_middleware.py` | Create class inheriting deepagents `MiddlewareBase`. Implement needed hooks: `before_model_call`, `after_model_call`, `awrap_tool_call`, `wrap_tool_call`. |
-| 2 | `src/rai/middleware/__init__.py` | Export: `from .my_middleware import MyMiddleware` |
-| 3 | `src/rai/engine/factory.py` | Insert into the middleware stack at the correct position (see Middleware Stack table). Add import at top. |
-| 4 | `src/rai/sdk/__init__.py` | Add to `__all__` so SDK users can import and compose it |
-| 5 | `AGENTS.md` (this file) | Add row to the Middleware Stack table with the correct position number |
-
----
-
-### Adding a new HTTP route / endpoint
-
-| # | File | What to do |
-|---|------|-----------|
-| 1 | `src/rai/harness/routes/my_route.py` | Create `APIRouter`. Define path functions with `async def`. |
-| 2 | `src/rai/harness/models.py` | Add Pydantic `BaseModel` classes for request body and response. |
-| 3 | `src/rai/harness/app.py` | `from .routes.my_route import router as my_router` and `app.include_router(my_router)` |
-| 4 | `src/rai/client/` | Add client method in the relevant client module (e.g. `threads.py`, `runs.py`) so users can call it via `RAIClient` |
-| 5 | `src/rai/sdk/__init__.py` | Export any new client method or model that belongs on the public surface |
-| 6 | `AGENTS.md` (this file) | Add endpoint row to the HTTP Server API table |
-
----
-
-### Adding a new SSE event type
-
-| # | File | What to do |
-|---|------|-----------|
-| 1 | `src/rai/harness/runner.py` | Call `await bus.publish("my_event", {...})` at the right point in `execute_run()` |
-| 2 | `src/rai/harness/sse.py` | No change needed unless adding a new bus type |
-| 3 | `src/rai/client/_events.py` | Add a dataclass or TypedDict for the new event, e.g. `MyEvent` |
-| 4 | `src/rai/client/_sse.py` | Add a branch in the SSE dispatcher to parse and yield the new event type |
-| 5 | `src/rai/sdk/__init__.py` | Export the new event class in `__all__` |
-| 6 | `src/rai/tui/app.py` | Add handler `on_my_event()` in `RaiHttpTUIApp` if the TUI needs to react to it |
-| 7 | `AGENTS.md` (this file) | Add row to the SSE event types table |
-
----
-
-### Adding a new default agent (seeded on first run)
-
-| # | File | What to do |
-|---|------|-----------|
-| 1 | `src/rai/data/prompts/<name>/prompt.md` | Write the bundled system prompt |
-| 2 | `src/rai/defaults/agents.py` | Add an entry to the `DEFAULT_AGENTS` list with `name`, `description`, `model` |
-| 3 | `~/.rai/agents/<name>/AGENTS.md` | Created automatically on first run — no manual step, but verify seeding logic covers the new name |
-| 4 | `AGENTS.md` (this file) | Add row to the Default Agents table |
-
----
-
-### Adding a new CLI command
-
-| # | File | What to do |
-|---|------|-----------|
-| 1 | `src/rai/cli/main.py` | Add `@app.command()` function, or create a new `typer.Typer()` sub-app and mount it with `app.add_typer(sub_app, name="...")` |
-| 2 | `src/rai/cli/<module>.py` | If the command logic is large, put it in a new module and import lazily inside the command function to keep startup fast |
-| 3 | `AGENTS.md` (this file) | Add to the CLI Commands section |
-
----
-
-### Exposing something to the SDK
-
-Every new public symbol (tool, middleware, event, client method, config class, helper) must be added to **both**:
-
-1. `src/rai/sdk/__init__.py` — add the import and add the name to `__all__`
-2. `AGENTS.md` (this file) — document in the relevant section
-
-The SDK `__init__.py` is the single source of truth for what external users can `from rai.sdk import`. If it is not in `__all__`, it is not part of the public API.
-
----
-
-## Examples
-
-See `examples/` for 12 runnable scripts:
-
-| File | Demonstrates |
-|------|-------------|
-| `01_pentest_agent.py` | Basic pentest workflow |
-| `02_sast_scanner.py` | Code analysis pipeline |
-| `03_red_team_parallel.py` | Multi-agent parallel coordination |
-| `04_bug_bounty_hunter.py` | Bug bounty automation |
-| `05_cloud_audit.py` | Cloud security assessment |
-| `06_ctf_solver.py` | CTF challenge solver |
-| `07_custom_middleware.py` | Extending middleware |
-| `08_minimal_custom.py` | Minimal SDK integration |
-| `09_sdk_cookbook.py` | Comprehensive SDK examples |
-| `10_threat_modeling.py` | Threat model generation |
-| `11_tui_custom_agent.py` | Custom TUI integration |
-| `12_tui_multi_agent.py` | Multi-agent TUI setup |
-
----
-
-## Dependencies (key)
-
-```
-deepagents==0.5.3          # Pinned — core agent framework, do NOT upgrade without regression
-deepagents-cli==0.0.41     # TUI widgets (AskUserMiddleware, LocalContextMiddleware, etc.)
-langchain>=1.2.15
-langgraph>=1.1.6
-langgraph-checkpoint-sqlite>=3.0.0
-langchain-anthropic
-langchain-litellm            # Multi-provider support
-textual>=8.0.0               # TUI framework
-fastapi>=0.115.0             # Required for rai chat / rai serve — included in the base install
-uvicorn[standard]>=0.30.0   # Same — included in the base install
-httpx
-uuid-utils                   # UUID7 thread IDs
+# Route through Burp Suite / mitmproxy
+RAI_INSPECT=1 RAI_INSPECT_PROXY=http://127.0.0.1:8080 rai chat
 ```
 
-**Install options:**
-- `pip install revolt-rai` — full install including `rai chat` and `rai serve`
+Wire temporarily into factory.py when needed:
+```python
+if os.environ.get("RAI_INSPECT", "0") == "1":
+    from rai.middleware.request_inspector import RequestInspectorMiddleware
+    agent_middleware.append(RequestInspectorMiddleware())
+```
 
-Model provider packages are optional extras: `langchain-openai`, `langchain-google-genai`, `langchain-aws`, `langchain-groq`, `langchain-openrouter`, `langchain-ollama`.
+**What it logs**: `ts`, `model`, `elapsed_ms`, `msg_count`, `total_chars`, `estimated_tokens`, `has_cache_control`, `by_type`, per-message preview.
+**Cross-check with**: `~/.rai/debug/model-calls.jsonl` from `ModelCallLoggerMiddleware` — both should show same message counts.
+
+---
+
+## Coding Conventions
+
+- **Python 3.11+**: `from __future__ import annotations`, `X | Y` unions, `TypedDict`
+- **Async I/O**: blocking calls in async context → `await asyncio.to_thread(fn, *args)`
+- **No comments** narrating what code does — names convey that
+- **Commit policy**: never commit unless user explicitly asks; no Co-Authored-By
+- **Textual widgets**: always use `_escape()` helper — never `rich.markup.escape()`
+- **Security**: `content_file` paths must validate against `/tmp/`, `$TMPDIR/`, `~/.rai/`
+- **JS SDK**: all state in `useReducer` — never `useSyncExternalStore` with external mutable store
+- **JS async loops**: use `dispatchRef.current()` and `processEventRef.current()` — never capture functions directly in SSE loop closures
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RAI_DEBUG_LOG_CALLS` | `0` | Set to `1` to enable `ModelCallLoggerMiddleware` → `~/.rai/debug/model-calls.jsonl` |
+| `RAI_DEBUG_LOG_FILE` | `~/.rai/debug/model-calls.jsonl` | Override debug log path |
+| `RAI_COMPACT_MSG_TRIGGER` | `40` | Message count that fires `SummarizationMiddleware` |
+| `RAI_COMPACT_TOKEN_TRIGGER` | `100000` | Token count that fires `SummarizationMiddleware` |
+| `RAI_COMPACT_KEEP` | `20` | Messages kept after summarization compaction |
+| `RAI_COMPACT_TRUNCATE_AT` | `30` | Depth at which old tool call args are truncated by summarizer |
+| `RAI_COMPACT_TRUNCATE_MAX` | `2000` | Max chars per tool arg after summarizer truncation |
+| `RAI_COMPACT_RESULT_KEEP` | `20` | `ToolResultCompressionMiddleware`: last N messages never touched |
+| `RAI_COMPACT_RESULT_MAX` | `1500` | `ToolResultCompressionMiddleware`: max chars for old tool results |
+| `RAI_COMPACT_CMD_MAX` | `600` | `ToolResultCompressionMiddleware`: max chars for old bash command args |
+| `RAI_COMPACT_FINDINGS_ARG_MAX` | `250` | `ToolResultCompressionMiddleware`: max chars for old findings_add description arg |
+| `RAI_LOOP_WINDOW` | `10` | `LoopDetectionMiddleware`: number of recent tool calls to track for dedup |
+| `RAI_LOOP_DISABLED` | `0` | Set to `1` to disable loop detection (debugging only) |
+| `RAI_COMPACT_MODEL` | — | Cheaper model for summarization (e.g. `litellm:openai/bedrock-claude-haiku-4.5-(US)`). Also set via `rai agents config-set --compact-model` |
+| `RAI_INSPECT` | `0` | Set to `1` to enable `RequestInspectorMiddleware` — logs full request to `~/.rai/debug/requests.jsonl` |
+| `RAI_INSPECT_PROXY` | — | MITM proxy for request inspection (e.g. `http://127.0.0.1:8080` for Burp/mitmproxy). Requires `RAI_INSPECT=1` |
+| `RAI_INSPECT_LOG_FILE` | `~/.rai/debug/requests.jsonl` | Override request inspector log path |
+| `RAI_MODEL_OVERRIDE` | — | Override model for all calls (`provider:model` format) |
+| `RAI_RATE_LIMIT_PROFILE` | `normal` | `aggressive` / `normal` / `stealth` |
+| `LITELLM_API_KEY` | — | API key for LiteLLM proxy (set by `factory.py` from `config.toml`) |
+| `LITELLM_BASE_URL` | — | Base URL for LiteLLM proxy |
+| `OPENAI_API_KEY` | — | OpenAI / LiteLLM proxy key (set by `factory.py`) |
+| `OPENAI_BASE_URL` | — | OpenAI / LiteLLM proxy URL (set by `factory.py`) |
+
+---
+
+## Release
+
+```
+# Python (revolt-rai on PyPI)
+git tag v2.0.1
+git push origin main && git push origin v2.0.1
+# → publish-pypi.yml triggers on GitHub Release
+
+# JS (@revolt-rai/js on npm)
+# Same tag triggers publish-npm.yml
+# Requires NPM_TOKEN secret
+
+# Docker (GHCR)
+# publish-docker-image.yml triggers on release / v* tag / main push
+```
+
+---
+
+## Install
+
+```bash
+pip install revolt-rai                    # Python CLI + TUI + HTTP server
+pip install revolt-rai[bedrock]           # + AWS Bedrock provider
+npm install @revolt-rai/js                # JS/TS SDK
+```
+
+> No `[http]` extra — `fastapi` and `uvicorn` are core deps since v2.0.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "revolt-rai"
-version = "2.0.0"
+version = "2.0.1"
 authors = [
     { name = "D. Sanjai Kumar" },
 ]
@@ -72,10 +72,16 @@ Repository = "https://github.com/RevoltSecurities/RAI"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rai"]
-include = ["static/**"]
+include = ["src/rai/**", "static/**"]
 
 [tool.hatch.build.targets.sdist]
-include = ["static/**"]
+include = [
+    "src/rai/**",
+    "static/**",
+    "pyproject.toml",
+    "README.md",
+    "LICENSE",
+]
 
 [tool.ruff]
 line-length = 120

--- a/release.md
+++ b/release.md
@@ -1,66 +1,100 @@
-# RAI v2.0.0 Release Notes
+# RAI v2.0.1 Release Notes
 
-RAI v2 is a full rewrite and release refresh of the open-source AI security operator. This version focuses on making the main workflow faster to start, easier to package, and broader in capability across autonomous security work.
+## What's New
 
-## Highlights
+### Token Cost Reduction (60–80% on long sessions)
 
-- `rai chat` is now part of the default install and starts the HTTP-backed TUI experience out of the box.
-- The HTTP server stack is included in the base package, so the main interactive flow works without extra dependencies.
-- The Docker image is now supported for local testing and GHCR publishing.
-- The project now ships with a single release commit history for the v2 baseline.
-- Versioning is aligned across the package, CLI, and runtime as `2.0.0`.
+RAI now runs a 3-layer compression pipeline before every model call, keeping costs flat as sessions grow longer:
 
-## Top Features in v2
+1. **History trim** — clips conversation to a token budget before the model sees it
+2. **Tool result compression** — old bash/grep/file outputs are truncated; recent results stay verbatim
+3. **Summarization** — only fires when the first two layers aren't enough
 
-### Interactive Security Operator
+Combined with a configurable cheap model for summarization, a typical VAPT or SAST session now costs significantly less than before.
 
-RAI is built to operate as a terminal-native security assistant, not a generic chat client. It can run autonomous tasks, manage approvals, and coordinate work through the CLI and TUI.
+**Configure a cheaper summarization model:**
+```bash
+rai agents config-set --compact-model "litellm:openai/bedrock-claude-haiku-4.5-(US)"
 
-### Plan Mode
+# With explicit credentials if different from main
+rai agents config-set \
+  --compact-model "litellm:openai/bedrock-claude-haiku-4.5-(US)" \
+  --compact-api-key "sk-..." \
+  --compact-base-url "https://llmproxy.example.com"
 
-Complex work can be broken into structured steps, reviewed before execution, and tracked live during the run. This is the main control point for high-trust autonomous workflows.
+# Clear it (inherit main model)
+rai agents config-set --compact-model ""
+```
 
-### Persistent Memory
+Also configurable via `RAI_COMPACT_MODEL` env var.
 
-RAI stores user, agent, and target memory across sessions so it can preserve methodology, findings, preferences, and target context over time.
+---
 
-### Multi-Agent Execution
+### Loop Detection
 
-RAI can dispatch specialized subagents for recon, research, code analysis, cloud work, reversing, Android analysis, and other focused tasks.
+The agent no longer gets stuck re-executing the same command. When identical tool calls are detected, RAI returns the cached result with a warning instead of executing again:
 
-### HTTP Streaming API
+```
+⚠ DUPLICATE CALL BLOCKED: 'bash' was already executed 5 times and returned:
+0 matches for shell_exec|proc_open|...
+This result is final. Accept it and proceed to the next step.
+```
 
-The FastAPI-backed server exposes runs, threads, tasks, subagents, HITL approval, and SSE event streams for remote control and TUI integration.
+Configurable: `RAI_LOOP_WINDOW=10` (default 10 recent calls tracked).
 
-### Textual TUI
+---
 
-The built-in TUI gives a rich operator interface for approvals, plan review, findings, threads, model selection, and background runs.
+### Plan Mode Improvements
 
-### MCP and Skills
+- Plan completion no longer repeats the full step history in the tool result — agent reads its own notes directly
+- `list_plan_steps` returns compact summaries for completed steps, full detail for pending ones
+- Memory phase at plan exit now explicitly guides the agent to write target-specific methodology to `scope='target'`
 
-RAI integrates with MCP tools and Markdown-based skills so capabilities can be extended without changing the core agent runtime.
+---
 
-### Security Tooling
+### TUI Improvements
 
-The toolkit covers bash execution, findings management, memory, references, web security, cloud, container, Active Directory, Android, and reversing workflows.
+- Thread resume now shows the **most recent messages** instead of the oldest
+- Internal control messages no longer appear as user messages in history
 
-### Docker and GHCR
+---
 
-The project now includes a container build path and a release workflow that publishes Docker images to GitHub Container Registry.
+### Model Call Diagnostics
 
-## Packaging Notes
+Enable detailed per-call logging to verify token consumption:
 
-- Base install: `pip install revolt-rai`
-- No extra is required for `rai chat`
-- Optional provider extras remain available for alternate model backends
+```bash
+RAI_DEBUG_LOG_CALLS=1 rai chat
+# Logs to ~/.rai/debug/model-calls.jsonl
+```
 
-## What Changed at a Glance
+Each entry shows: message count, total chars, estimated tokens, truncated count, message type breakdown.
 
-- Unified release version: `2.0.0`
-- Default interactive path now works without optional HTTP extras
-- Docker build and publish workflow added
-- Source tree and release metadata aligned for the v2 baseline
+---
 
-## Compatibility
+## Bug Fixes
 
-This release is intended as the new v2 baseline. If you are upgrading from an older branch, review agent configs, custom prompts, and any local workflows that assumed the older packaging layout.
+- `pip install revolt-rai` now works — previous wheel was empty due to packaging misconfiguration
+- Session approval (`approve_for_session`) now persists correctly across tool calls
+- Server shuts down cleanly when TUI exits or crashes
+- Thread resume loads with the correct agent graph when multiple agents are registered
+- Audit log no longer blocks the event loop on busy servers
+- `content_file` in `memory_write` now restricted to safe paths only
+
+---
+
+## Upgrade from v2.0.0
+
+No breaking changes. All existing agent configs, memories, and sessions work as-is.
+
+To enable cheaper summarization after upgrading:
+```bash
+rai agents config-set --compact-model "litellm:openai/bedrock-claude-haiku-4.5-(US)"
+```
+
+## Install
+
+```bash
+pip install revolt-rai          # Python CLI + TUI + HTTP server
+pip install revolt-rai[bedrock] # + AWS Bedrock provider
+```

--- a/src/rai/__init__.py
+++ b/src/rai/__init__.py
@@ -1,5 +1,5 @@
 """RAI — the open-source AI security operator for the full cybersecurity spectrum: threat modeling, SAST, pentesting, red team, bug bounty, VAPT, and SOC operations."""
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 # langchain_core's surface_langchain_deprecation_warnings() inserts a "default"
 # filter at position 0 when it is first imported, pushing any earlier "ignore"

--- a/src/rai/cli/http_server.py
+++ b/src/rai/cli/http_server.py
@@ -301,6 +301,9 @@ def _serve_with_tui(
     )
     uv_server = uvicorn.Server(uv_config)
 
+    # Prevent uvicorn from installing its own signal handlers — we manage shutdown.
+    uv_server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
+
     def _run_uvicorn() -> None:
         import asyncio as _asyncio
         loop = _asyncio.new_event_loop()
@@ -335,15 +338,28 @@ def _serve_with_tui(
     if debug_startup:
         typer.echo("Server ready. Opening TUI…")
 
-    launch_tui(
-        base_url=base,
-        agent=agent_names[0],
-        api_key=server_key,
-        thread_id=thread_id or None,
-    )
+    import signal
 
-    # Signal server to stop after TUI exits
-    uv_server.should_exit = True
+    def _shutdown(signum=None, frame=None):  # noqa: ARG001
+        uv_server.should_exit = True
+
+    # Ensure clean shutdown on Ctrl+C / SIGTERM even if TUI crashes
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _shutdown)
+        except (OSError, ValueError):
+            pass  # can't set signal handler in non-main thread — ignore
+
+    try:
+        launch_tui(
+            base_url=base,
+            agent=agent_names[0],
+            api_key=server_key,
+            thread_id=thread_id or None,
+        )
+    finally:
+        # Always stop the server when TUI exits, crashes, or is Ctrl+C'd
+        uv_server.should_exit = True
 
 
 # ── run (client: POST run + stream SSE to terminal) ───────────────────────────

--- a/src/rai/cli/main.py
+++ b/src/rai/cli/main.py
@@ -587,8 +587,19 @@ def agents_config_set(
     base_url: Annotated[Optional[str], typer.Option("--base-url", help="Custom API base URL (OpenAI-compatible endpoint)")] = None,
     temperature: Annotated[Optional[float], typer.Option("--temperature", help="Sampling temperature")] = None,
     max_tokens: Annotated[Optional[int], typer.Option("--max-tokens", help="Max output tokens")] = None,
+    compact_model: Annotated[Optional[str], typer.Option("--compact-model", help="Cheaper model for context summarization (empty = inherit main model). E.g. 'litellm:openai/bedrock-claude-haiku-4.5-(US)'")] = None,
+    compact_api_key: Annotated[Optional[str], typer.Option("--compact-api-key", help="API key for summarization model (empty = inherit main api-key)")] = None,
+    compact_base_url: Annotated[Optional[str], typer.Option("--compact-base-url", help="Base URL for summarization model (empty = inherit main base-url)")] = None,
 ) -> None:
-    """Set per-agent config values."""
+    """Set per-agent config values.
+
+    \b
+    Examples
+    --------
+        rai agents config-set --model "litellm:openai/bedrock-claude-sonnet-4.6-(US)" --api-key sk-...
+        rai agents config-set --compact-model "litellm:openai/bedrock-claude-haiku-4.5-(US)"
+        rai agents config-set --compact-model "" --compact-api-key ""   # clear (inherit from main)
+    """
     from rai.config.agent import load_agent_config, save_agent_config
     cfg = load_agent_config(name)
     if model is not None:
@@ -601,8 +612,18 @@ def agents_config_set(
         cfg.temperature = temperature
     if max_tokens is not None:
         cfg.max_tokens = max_tokens
+    if compact_model is not None:
+        cfg.compact_model = compact_model
+    if compact_api_key is not None:
+        cfg.compact_api_key = compact_api_key
+    if compact_base_url is not None:
+        cfg.compact_base_url = compact_base_url
     path = save_agent_config(name, cfg)
     console.print(f"[green]✓[/green] Saved config for agent '{name}' → {path}")
+    if cfg.compact_model:
+        console.print(f"[dim]  compact_model: {cfg.compact_model}[/dim]")
+    else:
+        console.print(f"[dim]  compact_model: (inherits main model)[/dim]")
 
 
 @agents_app.command("config-init")

--- a/src/rai/client/threads.py
+++ b/src/rai/client/threads.py
@@ -54,6 +54,30 @@ class ThreadsAPI:
             params={"limit": limit, "offset": offset},
         )
 
+    async def history_tail(self, thread_id: str, *, limit: int = 50) -> dict:
+        """Return the LAST `limit` messages — two-step fetch (probe total then tail).
+
+        The /history endpoint returns msgs[offset:offset+limit] — without an offset
+        it always returns the OLDEST messages. For resuming a thread in the TUI or
+        web UI, you want the most recent messages, not the first ones.
+        """
+        probe = await self._t.get(
+            f"/threads/{thread_id}/history",
+            params={"limit": 1, "offset": 0},
+        )
+        total: int = probe.get("total", 0)
+        if total <= limit:
+            # Short thread — one fetch covers everything
+            return await self._t.get(
+                f"/threads/{thread_id}/history",
+                params={"limit": limit, "offset": 0},
+            )
+        offset = total - limit
+        return await self._t.get(
+            f"/threads/{thread_id}/history",
+            params={"limit": limit, "offset": offset},
+        )
+
     async def delete(self, thread_id: str) -> dict:
         return await self._t.delete(f"/threads/{thread_id}")
 

--- a/src/rai/config/agent.py
+++ b/src/rai/config/agent.py
@@ -47,6 +47,13 @@ class AgentConfig:
     temperature: float = 0.7
     max_tokens: int = 8192
     rate_limit_profile: str = ""
+    # Summarization (compaction) model config.
+    # Empty = inherit from parent agent (model/api_key/base_url above).
+    # Set these to use a cheaper model (e.g. haiku) for context compaction
+    # without changing the main agent model.
+    compact_model: str = ""
+    compact_api_key: str = ""
+    compact_base_url: str = ""
 
     def is_empty(self) -> bool:
         """True when no meaningful overrides are set."""
@@ -65,6 +72,12 @@ class AgentConfig:
         lines.append(f"max_tokens = {self.max_tokens}")
         if self.rate_limit_profile:
             lines.append(f'rate_limit_profile = "{self.rate_limit_profile}"')
+        if self.compact_model:
+            lines.append(f'compact_model = "{self.compact_model}"')
+        if self.compact_api_key:
+            lines.append(f'compact_api_key = "{self.compact_api_key}"')
+        if self.compact_base_url:
+            lines.append(f'compact_base_url = "{self.compact_base_url}"')
         return "\n".join(lines) + "\n"
 
 
@@ -81,6 +94,7 @@ def load_agent_config(agent_name: str) -> AgentConfig:
     """
     # 1. config.toml — temperature/max_tokens + fallback model/api_key/base_url
     toml_model = toml_api_key = toml_base_url = ""
+    toml_compact_model = toml_compact_api_key = toml_compact_base_url = ""
     temperature = 0.7
     max_tokens = 8192
     rate_limit_profile = ""
@@ -96,6 +110,9 @@ def load_agent_config(agent_name: str) -> AgentConfig:
             temperature = float(data.get("temperature", 0.7))
             max_tokens = int(data.get("max_tokens", 8192))
             rate_limit_profile = str(data.get("rate_limit_profile", ""))
+            toml_compact_model = str(data.get("compact_model", ""))
+            toml_compact_api_key = str(data.get("compact_api_key", ""))
+            toml_compact_base_url = str(data.get("compact_base_url", ""))
         except Exception as exc:
             logger.warning("Could not read agent config %s: %s", path, exc)
 
@@ -125,6 +142,9 @@ def load_agent_config(agent_name: str) -> AgentConfig:
         temperature=temperature,
         max_tokens=max_tokens,
         rate_limit_profile=rate_limit_profile,
+        compact_model=toml_compact_model,
+        compact_api_key=toml_compact_api_key,
+        compact_base_url=toml_compact_base_url,
     )
 
 

--- a/src/rai/engine/factory.py
+++ b/src/rai/engine/factory.py
@@ -71,7 +71,7 @@ logger = logging.getLogger(__name__)
 # bloats the LangGraph checkpoint and accumulated message history.
 try:
     import deepagents.backends.utils as _dbu
-    _dbu.TOOL_RESULT_TOKEN_LIMIT = 8000
+    _dbu.TOOL_RESULT_TOKEN_LIMIT = 4000
 except Exception:
     pass
 
@@ -592,6 +592,26 @@ def create_rai_agent(
     if base_url:
         cfg.base_url = base_url
 
+    # Bridge RAI config credentials into os.environ so ConfigurableModelMiddleware
+    # (deepagents-cli) can find them. That middleware calls deepagents-cli's
+    # create_model() on every runtime model-context swap, which reads ONLY os.environ —
+    # it has no access to RAI's config.toml. Without this, any runtime model switch
+    # (e.g. /model command, TUI model picker, HTTP context injection) rebuilds the
+    # LLM using the wrong or missing credentials, hitting an expired/wrong key.
+    # Force-assign: config.toml api_key always wins unless an explicit non-empty
+    # env var was set BEFORE the process started (CLI env overrides).
+    # setdefault would silently skip empty-string env vars that block the real key.
+    if cfg.api_key:
+        if not os.environ.get("LITELLM_API_KEY"):
+            os.environ["LITELLM_API_KEY"] = cfg.api_key
+        if not os.environ.get("OPENAI_API_KEY"):
+            os.environ["OPENAI_API_KEY"] = cfg.api_key
+    if cfg.base_url:
+        if not os.environ.get("LITELLM_BASE_URL"):
+            os.environ["LITELLM_BASE_URL"] = cfg.base_url
+        if not os.environ.get("OPENAI_BASE_URL"):
+            os.environ["OPENAI_BASE_URL"] = cfg.base_url
+
     # Per-agent config model overrides CLI model only when CLI still has the bare default
     # and config has an explicit model set.  CLI --model always wins over config.
     effective_model: str | BaseChatModel
@@ -673,6 +693,15 @@ def create_rai_agent(
     #     No-ops silently when rtk is not installed or the command has no equivalent.
     if not disable_rtk:
         agent_middleware.append(RTKToolMiddleware())
+
+    # 3.5. Loop detection — prevents degenerate re-execution of identical tool calls.
+    #      When the agent re-derives the same bash/grep/read_file call under context
+    #      pressure, returns the cached result immediately with a ⚠ warning instead
+    #      of executing again. Stops 50× same-command loops like the grep degenerate.
+    from rai.middleware.loop_detection import LoopDetectionMiddleware
+    agent_middleware.append(LoopDetectionMiddleware(
+        window=int(os.environ.get("RAI_LOOP_WINDOW", 10)),
+    ))
 
     # 4. Execute interceptor — routes deepagents' built-in execute tool through
     #    RAI BashTool (env isolation, stderr labelling, /tmp spill, allowlist).
@@ -791,9 +820,26 @@ def create_rai_agent(
     from rai.middleware.model_override import ModelOverrideMiddleware  # lazy
     agent_middleware.append(ModelOverrideMiddleware())
 
-    # 10.5. Message compression — trim history to ~30k tokens before summarization fires.
-    #        Zero LLM cost. Pre-filter so SummarizationMiddleware fires less frequently.
+
+    # 10.5. Message compression — trim history to ~30k tokens before model call.
+    #        Zero LLM cost. Pre-filter: reduces token cost on every call and gives
+    #        SummarizationMiddleware (layer 11) a smaller window to work with.
+    #        Order is correct: compress first → then summarize if still too large.
+    #        The compression.py _char_estimate() fix (includes tool_call args) ensures
+    #        this now accurately measures the 75k char budget.
     agent_middleware.append(MessageCompressionMiddleware())
+
+    # 10.7. Tool result compaction — truncate old bash/file/http results and bash
+    #        command args. Zero LLM cost. Never touches: human messages (carry
+    #        <system-reminder> plan enforcement + subagent notifications), plan tools,
+    #        findings, memory, ask_user. Saves 60-80% context on long security sessions.
+    from rai.middleware.tool_compaction import ToolResultCompressionMiddleware
+    agent_middleware.append(ToolResultCompressionMiddleware(
+        keep_recent=int(os.environ.get("RAI_COMPACT_RESULT_KEEP", 20)),
+        max_result_chars=int(os.environ.get("RAI_COMPACT_RESULT_MAX", 1500)),
+        max_cmd_chars=int(os.environ.get("RAI_COMPACT_CMD_MAX", 600)),
+        max_findings_arg_chars=int(os.environ.get("RAI_COMPACT_FINDINGS_ARG_MAX", 250)),
+    ))
 
     # 11. Summarization tool + early-fire safety valve.
     #
@@ -831,8 +877,38 @@ def create_rai_agent(
         _keep             = int(os.environ.get("RAI_COMPACT_KEEP",          20))
         _truncate_at      = int(os.environ.get("RAI_COMPACT_TRUNCATE_AT",   30))
         _truncate_max     = int(os.environ.get("RAI_COMPACT_TRUNCATE_MAX",  2000))
+        # Summarization model: use cfg.compact_model if set, else fall back to
+        # resolved_model (main agent model). Empty = inherit parent model/key/url.
+        # Configure via: rai agents config-set --compact-model "litellm:openai/bedrock-claude-haiku-4.5-(US)"
+        # or env var: RAI_COMPACT_MODEL
+        _summ_model = resolved_model  # default: same as main agent
+        _compact_model_str = (
+            os.environ.get("RAI_COMPACT_MODEL", "")   # env var wins
+            or cfg.compact_model                       # config.toml compact_model
+        )
+        if _compact_model_str:
+            try:
+                _compact_api_key  = cfg.compact_api_key  or cfg.api_key   # inherit if empty
+                _compact_base_url = cfg.compact_base_url or cfg.base_url  # inherit if empty
+                _summ_model = _build_llm(
+                    _compact_model_str,
+                    api_key=_compact_api_key,
+                    base_url=_compact_base_url,
+                    temperature=0.5,
+                    max_tokens=4096,
+                )
+                logger.debug(
+                    "Using compact model for summarization: %s (api_key=%s, base_url=%s)",
+                    _compact_model_str,
+                    bool(_compact_api_key),
+                    bool(_compact_base_url),
+                )
+            except Exception:
+                logger.debug("Failed to build compact model, falling back to main model", exc_info=True)
+                _summ_model = resolved_model
+
         _summ_auto = SummarizationMiddleware(
-            model=resolved_model,
+            model=_summ_model,
             backend=composite_backend,
             trigger=[("tokens", _tok_trigger), ("messages", _msg_trigger)],
             keep=("messages", _keep),

--- a/src/rai/harness/plan/tools.py
+++ b/src/rai/harness/plan/tools.py
@@ -601,6 +601,23 @@ async def list_plan_steps() -> str:
     by_status: dict[str, int] = {}
     for s in steps:
         by_status[s["status"]] = by_status.get(s["status"], 0) + 1
+    # Compact done/blocked steps — strip description/how_to/full-notes to save tokens.
+    # Pending and in_progress steps are returned in full so the agent has complete detail.
+    # notes are summarised to 150 chars for done steps (full notes in mark_step_done ToolMessages).
+    def _compact_step(s: dict) -> dict:
+        status = s.get("status", "")
+        if status in ("done", "blocked"):
+            notes = s.get("notes", "") or ""
+            reason = s.get("reason", "") or ""
+            return {
+                "number": s["number"],
+                "title":  s.get("title") or s.get("description", ""),
+                "status": status,
+                "notes":  (notes[:150] + "…") if len(notes) > 150 else notes,
+                "reason": (reason[:150] + "…") if len(reason) > 150 else reason,
+            }
+        return s  # pending/in_progress: full detail
+
     return json.dumps({
         "plan_title":  plan_data.get("title", "Plan"),
         "total":       len(steps),
@@ -608,7 +625,7 @@ async def list_plan_steps() -> str:
         "blocked":     by_status.get("blocked", 0),
         "in_progress": by_status.get("in_progress", 0),
         "pending":     by_status.get("pending", 0),
-        "steps":       steps,
+        "steps":       [_compact_step(s) for s in steps],
     }, indent=2)
 
 
@@ -865,36 +882,27 @@ async def exit_plan_mode() -> str:
     done_steps    = [s for s in steps if s["status"] == "done"]
     blocked_steps = [s for s in steps if s["status"] == "blocked"]
 
-    notes_lines: list[str] = []
-    for s in steps:
-        note   = s.get("notes", "")
-        reason = s.get("reason", "")
-        suffix = f" — {note}" if note else (f" — blocked: {reason}" if reason else "")
-        label  = s.get("title") or s.get("description", "—")
-        notes_lines.append(f"  {s['number']}. [{s['status']}] {label}{suffix}")
-    step_digest = "\n".join(notes_lines) if notes_lines else "  (no steps recorded)"
-
+    # Compact result — step digest removed (agent reads mark_step_done ToolMessages directly).
+    target_name = plan_data.get("target") or reg.get("metadata", {}).get("target", "")
+    target_line = (
+        f"\n  memory_write(scope='target', file='methodology') — NEW techniques specific to this target\n"
+        f"  memory_write(scope='target', file='notes')       — target-{target_name}: key facts, quirks, credentials\n"
+        if target_name else
+        "\n  memory_write(scope='target', file='methodology') — if a target is active, write target-specific techniques\n"
+    )
     return (
         f"All plan steps complete "
         f"({len(done_steps)} done, {len(blocked_steps)} blocked) — "
         f"'{plan_data.get('title', 'Plan')}'\n\n"
         "── SELF-LEARNING MEMORY PHASE ──────────────────────────────────────────\n"
-        "Before writing your final summary, reflect on what you learned and write\n"
-        "memory entries using memory_write (scope='agent') for anything worth\n"
-        "preserving for future runs. Use the step digest below as your source.\n\n"
-        f"Step execution digest:\n{step_digest}\n\n"
-        "Write entries for each category that applies:\n\n"
-        "  🎯 TARGET / PROJECT FACTS\n"
-        "     New non-obvious knowledge: tech stack, endpoints, credential patterns,\n"
-        "     API quirks, exposed services, config specifics, architecture details.\n\n"
-        "  🔬 METHODOLOGY\n"
-        "     What research or execution approaches worked well (or poorly).\n"
-        "     Techniques, tool combinations, ordering that was effective.\n\n"
-        "  🚧 BLOCKERS & WORKAROUNDS\n"
-        "     What was blocked, why, and how resolved (or not).\n\n"
-        "  💡 LESSONS LEARNED\n"
-        "     Edge cases hit, wrong assumptions corrected, things to do differently.\n\n"
-        "Skip categories where you have nothing new to record.\n"
+        "Read your mark_step_done notes above. Write ONLY entries that are NEW —\n"
+        "skip anything already in memory. Use these tools:\n\n"
+        "  memory_write(scope='agent', file='methodology')  — NEW techniques you used that\n"
+        "    aren't in methodology.md yet (tool combos, attack patterns, ordering that worked)\n"
+        f"{target_line}"
+        "  memory_write(scope='agent', file='feedback')     — wrong assumptions, lessons learned\n"
+        "  memory_write(scope='agent', file='user')         — anything new about user preferences\n\n"
+        "Before writing: call memory_read first to check what already exists — avoid duplicates.\n"
         "────────────────────────────────────────────────────────────────────────\n\n"
         "After writing memories, provide your final summary: what was accomplished,\n"
         "key findings, anything blocked and why, and recommended next steps."

--- a/src/rai/middleware/__init__.py
+++ b/src/rai/middleware/__init__.py
@@ -14,6 +14,8 @@ except ImportError:
     RAIPromptCachingMiddleware = None  # type: ignore[assignment,misc]
 from rai.middleware.model_logger import ModelCallLoggerMiddleware
 from rai.middleware.rtk import RTKToolMiddleware
+from rai.middleware.tool_compaction import ToolResultCompressionMiddleware
+from rai.middleware.loop_detection import LoopDetectionMiddleware
 
 __all__ = [
     "EmptyContentSanitizerMiddleware",
@@ -27,4 +29,6 @@ __all__ = [
     "RAIPromptCachingMiddleware",
     "ModelCallLoggerMiddleware",
     "RTKToolMiddleware",
+    "ToolResultCompressionMiddleware",
+    "LoopDetectionMiddleware",
 ]

--- a/src/rai/middleware/compression.py
+++ b/src/rai/middleware/compression.py
@@ -18,16 +18,36 @@ logger = logging.getLogger(__name__)
 
 
 def _char_estimate(msg: Any) -> int:
-    """Estimate character count for a single message (used as token_counter)."""
+    """Estimate character count for a single message including tool call args.
+
+    Counts content field + tool_calls[].args JSON so the budget reflects
+    the true token cost. Previously only counted content, causing the fast-path
+    check to under-count AI messages with large bash command args, allowing
+    the total to exceed the 75k char budget.
+    """
+    import json as _json
+
+    total = 0
+
+    # Content field (plain text or list of blocks)
     c = getattr(msg, "content", "")
     if isinstance(c, str):
-        return len(c)
-    if isinstance(c, list):
-        return sum(
+        total += len(c)
+    elif isinstance(c, list):
+        total += sum(
             len(b.get("text", "")) if isinstance(b, dict) else 0
             for b in c
         )
-    return 0
+
+    # Tool call args — AI messages with large bash commands or http_request bodies
+    for tc in getattr(msg, "tool_calls", None) or []:
+        args = tc.get("args", {}) if isinstance(tc, dict) else {}
+        try:
+            total += len(_json.dumps(args))
+        except (TypeError, ValueError):
+            total += len(str(args))
+
+    return total
 
 
 class MessageCompressionMiddleware(AgentMiddleware):

--- a/src/rai/middleware/loop_detection.py
+++ b/src/rai/middleware/loop_detection.py
@@ -1,0 +1,148 @@
+"""LoopDetectionMiddleware — prevent degenerate tool call loops.
+
+Detects when the agent issues the exact same tool call (same name + same args)
+that it already executed and received a result for within the last N turns.
+When detected, short-circuits re-execution and returns the cached result with
+a warning that tells the model to accept it and move on.
+
+Root cause this fixes:
+  Under context pressure, the agent re-derives the same "next action" from
+  degraded context — not realising it already ran that command. Without this
+  guard, the same grep/bash command executes 50+ times in a row.
+
+What it does:
+  - Maintains a sliding window LRU cache of (tool_name, args_hash) → result
+  - On every tool call: checks if identical call was already executed recently
+  - If duplicate: returns cached result immediately with ⚠ warning, NO re-exec
+  - If new: executes normally and caches the result
+
+Configurable via env vars:
+  RAI_LOOP_WINDOW   — recent tool calls to track (default: 10)
+  RAI_LOOP_DISABLED — set to 1 to disable (for debugging)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from collections import OrderedDict
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import ToolMessage
+
+logger = logging.getLogger(__name__)
+
+_WINDOW_DEFAULT = 10
+
+
+def _hash_call(tool_name: str, tool_input: dict) -> str:
+    """Stable hash of tool_name + args for deduplication."""
+    try:
+        key = json.dumps({"n": tool_name, "a": tool_input}, sort_keys=True)
+    except (TypeError, ValueError):
+        key = f"{tool_name}:{str(tool_input)}"
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+class LoopDetectionMiddleware(AgentMiddleware):
+    """Prevent the agent from re-executing identical tool calls.
+
+    Maintains a sliding window of recent (hash → result) pairs.
+    Duplicate calls within the window return the cached result immediately
+    with a warning that instructs the agent to accept the result and move on.
+
+    Fail-open: any exception falls through to normal execution.
+    """
+
+    def __init__(self, window: int | None = None) -> None:
+        self._window = window or int(os.environ.get("RAI_LOOP_WINDOW", _WINDOW_DEFAULT))
+        # LRU: hash → (tool_name, tool_call_id, short_result, count)
+        self._cache: OrderedDict[str, tuple[str, str, str, int]] = OrderedDict()
+        self._disabled = os.environ.get("RAI_LOOP_DISABLED", "0") == "1"
+
+    def _get_duplicate(
+        self, tool_name: str, tool_input: dict, tool_call_id: str
+    ) -> ToolMessage | None:
+        """Return a cached ToolMessage if this call is a duplicate, else None."""
+        if self._disabled:
+            return None
+
+        h = _hash_call(tool_name, tool_input)
+        if h not in self._cache:
+            return None
+
+        _name, _orig_id, short_result, count = self._cache[h]
+        self._cache[h] = (_name, _orig_id, short_result, count + 1)
+        self._cache.move_to_end(h)
+
+        logger.warning(
+            "LoopDetectionMiddleware: duplicate call blocked "
+            "(tool=%s, count=%d)", tool_name, count + 1,
+        )
+
+        warning = (
+            f"⚠ DUPLICATE CALL BLOCKED: '{tool_name}' with these exact arguments "
+            f"was already executed {count} time(s) and returned:\n\n"
+            f"{short_result}\n\n"
+            f"This result is final. Do NOT re-issue this command. "
+            f"Accept the result above and proceed to the next step."
+        )
+        return ToolMessage(content=warning, tool_call_id=tool_call_id)
+
+    def _record(self, tool_name: str, tool_input: dict, tool_call_id: str, result: Any) -> None:
+        """Cache this tool call result, evicting oldest if window exceeded."""
+        h = _hash_call(tool_name, tool_input)
+        short = str(result)[:400] if result is not None else "(no output)"
+        self._cache[h] = (tool_name, tool_call_id, short, 1)
+        self._cache.move_to_end(h)
+        while len(self._cache) > self._window:
+            self._cache.popitem(last=False)
+
+    def _extract(self, request: Any) -> tuple[str, dict, str]:
+        """Extract (tool_name, tool_input, tool_call_id) from a ToolCallRequest."""
+        tc = request.tool_call if hasattr(request, "tool_call") else {}
+        if not isinstance(tc, dict):
+            tc = {}
+        name = tc.get("name", "") or ""
+        inp  = tc.get("args", {}) or {}
+        tid  = tc.get("id", "") or ""
+        return name, inp, tid
+
+    def wrap_tool_call(self, request: Any, handler: Any) -> Any:
+        try:
+            name, inp, tid = self._extract(request)
+            dup = self._get_duplicate(name, inp, tid)
+            if dup is not None:
+                return dup
+
+            result = handler(request)
+            try:
+                out = result.content if isinstance(result, ToolMessage) else str(result)
+                self._record(name, inp, tid, out)
+            except Exception:
+                pass
+            return result
+        except Exception:
+            logger.debug("LoopDetectionMiddleware.wrap_tool_call error", exc_info=True)
+            return handler(request)
+
+    async def awrap_tool_call(self, request: Any, handler: Any) -> Any:
+        try:
+            name, inp, tid = self._extract(request)
+            dup = self._get_duplicate(name, inp, tid)
+            if dup is not None:
+                return dup
+
+            result = await handler(request)
+            try:
+                out = result.content if isinstance(result, ToolMessage) else str(result)
+                self._record(name, inp, tid, out)
+            except Exception:
+                pass
+            return result
+        except Exception:
+            logger.debug("LoopDetectionMiddleware.awrap_tool_call error", exc_info=True)
+            return await handler(request)

--- a/src/rai/middleware/model_logger.py
+++ b/src/rai/middleware/model_logger.py
@@ -7,6 +7,19 @@ context compaction is working correctly.
 
 Log path defaults to ~/.rai/debug/model-calls.jsonl and can be overridden
 with RAI_DEBUG_LOG_FILE.
+
+Log fields:
+  ts                — ISO timestamp
+  effective_count   — ACCURATE: exact messages sent to model this call
+  total_chars       — ACCURATE: total character count of all messages sent
+  estimated_tokens  — ACCURATE: estimated tokens (2.5 chars/token)
+  compressed        — whether SummarizationMiddleware has fired before
+  cutoff_index      — raw message index where summarization cut (if compressed)
+  raw_session_total — estimated total messages ever in this session
+  truncated_count   — messages that were truncated by ToolResultCompressionMiddleware
+  by_type           — message type breakdown {human, ai, tool, system}
+  tool_count        — number of tools registered
+  messages          — first 200 chars preview of each message sent
 """
 
 from __future__ import annotations
@@ -16,12 +29,48 @@ import os
 from collections.abc import Awaitable, Callable
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
 
+_CHARS_PER_TOKEN = 2.5
+
+
+def _msg_chars(msg: Any) -> int:
+    """Total character count of a message including tool call args."""
+    total = 0
+    content = getattr(msg, "content", "") or ""
+    if isinstance(content, str):
+        total += len(content)
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                total += len(block.get("text", ""))
+
+    # Count tool call args (AI messages)
+    for tc in getattr(msg, "tool_calls", None) or []:
+        args = tc.get("args", {}) if isinstance(tc, dict) else {}
+        total += len(json.dumps(args))
+
+    return total
+
+
+def _is_truncated(msg: Any) -> bool:
+    """Detect if ToolResultCompressionMiddleware truncated this message."""
+    content = getattr(msg, "content", "") or ""
+    if isinstance(content, str) and "chars truncated)" in content:
+        return True
+    # Check truncated tool call args
+    for tc in getattr(msg, "tool_calls", None) or []:
+        args = tc.get("args", {}) if isinstance(tc, dict) else {}
+        for v in args.values():
+            if isinstance(v, str) and "(truncated)" in v:
+                return True
+    return False
+
 
 class ModelCallLoggerMiddleware(AgentMiddleware):
-    """Log every model call (message counts, compression state) to a JSONL file."""
+    """Log every model call with accurate counts to a JSONL file."""
 
     def __init__(self, log_path: str | Path | None = None) -> None:
         super().__init__()
@@ -34,25 +83,50 @@ class ModelCallLoggerMiddleware(AgentMiddleware):
 
     def _build_entry(self, request: ModelRequest) -> dict:
         msgs = request.messages or []
-        effective_count = len(msgs)
+        effective_count = len(msgs)  # ACCURATE — exact count sent to model
 
+        # Token / char stats
+        total_chars = sum(_msg_chars(m) for m in msgs)
+        estimated_tokens = int(total_chars / _CHARS_PER_TOKEN)
+
+        # Summarization state
         summ_event = (request.state or {}).get("_summarization_event") or {}
         cutoff_index: int = summ_event.get("cutoff_index", 0) if summ_event else 0
         compressed = bool(summ_event)
-        recent_kept = (effective_count - 1) if compressed else effective_count
-        raw_approx = (cutoff_index + recent_kept) if compressed else effective_count
+        # raw_session_total: cutoff (summarized msgs) + current effective
+        # subtract 1 for the summary msg itself when compressed
+        raw_session_total = (cutoff_index + effective_count - 1) if compressed else effective_count
+
+        # Message type breakdown
+        by_type: dict[str, int] = {}
+        for m in msgs:
+            t = getattr(m, "type", type(m).__name__)
+            by_type[t] = by_type.get(t, 0) + 1
+
+        # Truncation stats from ToolResultCompressionMiddleware
+        truncated_count = sum(1 for m in msgs if _is_truncated(m))
 
         return {
-            "ts":              datetime.now().isoformat(),
-            "effective_count": effective_count,
-            "raw_approx":      raw_approx,
-            "compressed":      compressed,
-            "cutoff_index":    cutoff_index if compressed else None,
-            "tool_count":      len(request.tools or []),
+            "ts":               datetime.now().isoformat(),
+            # ── Accurate counts ──────────────────────────────────────────────
+            "effective_count":  effective_count,    # exact messages sent to model
+            "total_chars":      total_chars,         # exact chars sent
+            "estimated_tokens": estimated_tokens,    # total_chars / 2.5
+            # ── Session history ──────────────────────────────────────────────
+            "compressed":       compressed,
+            "cutoff_index":     cutoff_index if compressed else None,
+            "raw_session_total": raw_session_total,  # total msgs ever in session
+            # ── Compression stats ────────────────────────────────────────────
+            "truncated_count":  truncated_count,     # msgs truncated by ToolResultCompression
+            "by_type":          by_type,              # {human:N, ai:N, tool:N, system:N}
+            "tool_count":       len(request.tools or []),
+            # ── Per-message preview ──────────────────────────────────────────
             "messages": [
                 {
-                    "type":            getattr(m, "type", type(m).__name__),
-                    "content_preview": str(getattr(m, "content", ""))[:200],
+                    "type":     getattr(m, "type", type(m).__name__),
+                    "chars":    _msg_chars(m),
+                    "truncated": _is_truncated(m),
+                    "preview":  str(getattr(m, "content", ""))[:200],
                 }
                 for m in msgs
             ],

--- a/src/rai/middleware/request_inspector.py
+++ b/src/rai/middleware/request_inspector.py
@@ -1,0 +1,216 @@
+"""RequestInspectorMiddleware — debug middleware for inspecting LLM requests live.
+
+FOR TESTING ONLY — revert before production release.
+
+Two modes:
+  1. Log mode (default): logs full request details to ~/.rai/debug/requests.jsonl
+     Shows: model, messages, token counts, tool names, cache_control presence
+  2. Proxy mode: routes all LLM requests through a local MITM proxy (e.g. mitmproxy)
+     Set RAI_INSPECT_PROXY=http://127.0.0.1:8080 to capture in mitmproxy/Burp/Charles
+
+Activation:
+  RAI_INSPECT=1                    — enable request logging
+  RAI_INSPECT_PROXY=http://...     — also route through MITM proxy
+  RAI_INSPECT_LOG_FILE=<path>      — override log path
+
+Usage with mitmproxy:
+  # Terminal 1: start mitmproxy
+  mitmproxy --listen-port 8080 --ssl-insecure
+
+  # Terminal 2: start RAI with proxy
+  RAI_INSPECT=1 RAI_INSPECT_PROXY=http://127.0.0.1:8080 rai chat
+
+  # mitmproxy will show every request to your LiteLLM proxy / Anthropic API
+  # including full message payloads, headers, response times
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+
+logger = logging.getLogger(__name__)
+
+_ENABLED = os.environ.get("RAI_INSPECT", "0") == "1"
+_PROXY = os.environ.get("RAI_INSPECT_PROXY", "")
+_LOG_FILE = os.environ.get(
+    "RAI_INSPECT_LOG_FILE",
+    str(Path.home() / ".rai" / "debug" / "requests.jsonl"),
+)
+
+
+def _msg_preview(msg: Any) -> dict:
+    """Compact message representation for logging."""
+    mtype = getattr(msg, "type", type(msg).__name__)
+    content = getattr(msg, "content", "") or ""
+    if isinstance(content, list):
+        content = " ".join(
+            b.get("text", "") if isinstance(b, dict) else "" for b in content
+        )
+    tool_calls = [
+        {"name": tc.get("name", ""), "args_len": len(json.dumps(tc.get("args", {})))}
+        for tc in (getattr(msg, "tool_calls", None) or [])
+    ]
+    cache = any(
+        (b.get("cache_control") if isinstance(b, dict) else False)
+        for b in (content if isinstance(getattr(msg, "content", None), list) else [])
+    )
+    entry = {
+        "type": mtype,
+        "chars": len(str(content)),
+        "preview": str(content)[:120],
+        "cached": cache,
+    }
+    if tool_calls:
+        entry["tool_calls"] = tool_calls
+    return entry
+
+
+def _inject_proxy(model: Any) -> Any:
+    """Patch the LLM client to route through RAI_INSPECT_PROXY (e.g. Burp/mitmproxy).
+
+    Burp Suite acts as a MITM and presents its own certificate — SSL verification
+    must be disabled or Python will refuse the connection.
+    """
+    if not _PROXY:
+        return model
+    try:
+        import httpx
+
+        # verify=False: accept Burp/mitmproxy self-signed cert
+        proxy_transport = httpx.HTTPTransport(proxy=_PROXY, verify=False)
+        async_proxy_transport = httpx.AsyncHTTPTransport(proxy=_PROXY, verify=False)
+        proxy_client = httpx.Client(transport=proxy_transport, verify=False)
+        async_proxy_client = httpx.AsyncClient(transport=async_proxy_transport, verify=False)
+
+        # ChatAnthropic: patch its internal httpx clients directly
+        _anthropic_client = getattr(model, "client", None)
+        if _anthropic_client is not None:
+            if hasattr(_anthropic_client, "_client"):
+                _anthropic_client._client = proxy_client
+            if hasattr(model, "async_client") and hasattr(model.async_client, "_client"):
+                model.async_client._client = async_proxy_client
+            logger.warning("RequestInspectorMiddleware: patched ChatAnthropic → %s", _PROXY)
+
+        # ChatLiteLLM: set env vars — LiteLLM reads HTTPS_PROXY + SSL_VERIFY on each call
+        os.environ["HTTPS_PROXY"] = _PROXY
+        os.environ["HTTP_PROXY"] = _PROXY
+        # Disable SSL verification for Burp/mitmproxy MITM certificate
+        os.environ["LITELLM_SSL_VERIFY"] = "false"
+        os.environ["SSL_VERIFY"] = "false"
+        os.environ["CURL_CA_BUNDLE"] = ""        # disables curl SSL verify
+        os.environ["REQUESTS_CA_BUNDLE"] = ""    # disables requests SSL verify
+        logger.warning(
+            "RequestInspectorMiddleware: HTTPS_PROXY=%s SSL_VERIFY=false", _PROXY
+        )
+    except Exception as e:
+        logger.warning("RequestInspectorMiddleware: proxy inject failed: %s", e)
+    return model
+
+
+def _write(entry: dict) -> None:
+    try:
+        Path(_LOG_FILE).parent.mkdir(parents=True, exist_ok=True)
+        with open(_LOG_FILE, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass
+
+
+class RequestInspectorMiddleware(AgentMiddleware):
+    """Debug middleware — logs full LLM request details + optional MITM proxy routing.
+
+    FOR TESTING ONLY. Remove from middleware stack before production release.
+    Activate with: RAI_INSPECT=1 [RAI_INSPECT_PROXY=http://127.0.0.1:8080]
+    """
+
+    def __init__(self) -> None:
+        self._enabled = _ENABLED
+        self._proxy_injected = False
+        if self._enabled and _PROXY:
+            logger.warning(
+                "RequestInspectorMiddleware: MITM proxy active → %s", _PROXY
+            )
+        elif self._enabled:
+            logger.warning(
+                "RequestInspectorMiddleware: request logging active → %s", _LOG_FILE
+            )
+
+    def _build_entry(self, request: ModelRequest, elapsed_ms: float) -> dict:
+        msgs = request.messages or []
+        model_name = ""
+        try:
+            model_name = str(getattr(request.model, "model", "") or type(request.model).__name__)
+        except Exception:
+            pass
+
+        # Cache control presence
+        has_cache = any(
+            isinstance(getattr(m, "content", None), list) and
+            any(isinstance(b, dict) and b.get("cache_control") for b in m.content)
+            for m in msgs
+        )
+
+        # Count by type
+        by_type: dict[str, int] = {}
+        for m in msgs:
+            t = getattr(m, "type", "?")
+            by_type[t] = by_type.get(t, 0) + 1
+
+        total_chars = sum(
+            len(str(getattr(m, "content", "") or "")) +
+            sum(len(json.dumps(tc.get("args", {})))
+                for tc in (getattr(m, "tool_calls", None) or []))
+            for m in msgs
+        )
+
+        return {
+            "ts": datetime.now().isoformat(),
+            "model": model_name,
+            "elapsed_ms": round(elapsed_ms, 1),
+            "msg_count": len(msgs),
+            "total_chars": total_chars,
+            "estimated_tokens": int(total_chars / 2.5),
+            "has_cache_control": has_cache,
+            "by_type": by_type,
+            "proxy": _PROXY or None,
+            "messages": [_msg_preview(m) for m in msgs],
+        }
+
+    def _ensure_proxy(self, request: ModelRequest) -> None:
+        """Inject proxy into model client once."""
+        if _PROXY and not self._proxy_injected:
+            _inject_proxy(request.model)
+            self._proxy_injected = True
+
+    def wrap_model_call(self, request: ModelRequest, handler: Callable) -> ModelResponse:
+        if not self._enabled:
+            return handler(request)
+        self._ensure_proxy(request)
+        t0 = time.monotonic()
+        result = handler(request)
+        elapsed = (time.monotonic() - t0) * 1000
+        _write(self._build_entry(request, elapsed))
+        return result
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        if not self._enabled:
+            return await handler(request)
+        self._ensure_proxy(request)
+        t0 = time.monotonic()
+        result = await handler(request)
+        elapsed = (time.monotonic() - t0) * 1000
+        _write(self._build_entry(request, elapsed))
+        return result

--- a/src/rai/middleware/tool_compaction.py
+++ b/src/rai/middleware/tool_compaction.py
@@ -1,0 +1,218 @@
+"""ToolResultCompressionMiddleware — truncate old tool results/args before model call.
+
+Sits between MessageCompressionMiddleware (layer 10.5) and SummarizationMiddleware
+(layer 11). Zero LLM cost. Runs on every model call.
+
+What it compacts:
+  - Old ToolMessage results from bash/grep/file/http tools (>500 chars)
+    → keep first 1500 chars + "\n...(+N chars truncated)"
+  - Old AI tool_call args for bash commands (>600 chars)
+    → keep first 600 chars + "...(truncated)"
+  - Old AI tool_call args for findings_add description (>250 chars)
+    → keep first 250 chars + "...(recorded in findings store)"
+
+What it NEVER touches:
+  - Any HumanMessage — <system-reminder> tags carry plan enforcement,
+    subagent notifications, findings counts, HITL signals
+  - SystemMessage — system prompt is always preserved
+  - The last `keep_recent` messages (default: 20) — verbatim for agent reasoning
+  - ToolMessage results from plan, findings, memory, ask_user tools
+  - Any result already short (< min_chars, default: 500 chars)
+
+Env vars for tuning:
+  RAI_COMPACT_RESULT_KEEP      — last N messages never touched (default: 20)
+  RAI_COMPACT_RESULT_MAX       — max chars for tool results (default: 1500)
+  RAI_COMPACT_CMD_MAX          — max chars for bash command args (default: 600)
+  RAI_COMPACT_FINDINGS_ARG_MAX — max chars for findings_add description (default: 250)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+logger = logging.getLogger(__name__)
+
+# ── Tools whose ToolMessage results must never be truncated ──────────────────
+
+_NEVER_TRUNCATE_TOOL_RESULTS = frozenset({
+    # Plan harness — all 7 tools
+    "enter_plan_mode", "write_plan", "list_plan_steps",
+    "enter_step", "mark_step_done", "mark_step_blocked", "exit_plan_mode",
+    # Findings — agent's recorded security discoveries
+    "findings_add", "findings_list", "findings_export",
+    # Memory — agent's persistent knowledge base
+    "memory_read", "memory_write", "memory_update", "memory_path",
+    "memory_files_list",
+    # HITL — ask_user answers are decisions, not bulk data
+    "ask_user",
+    # Compact conversation — summarization control
+    "compact_conversation",
+})
+
+# ── Tools whose AI tool_call ARGS must never be bulk-truncated ───────────────
+# (findings_add gets special partial truncation — only description field)
+
+_NEVER_TRUNCATE_ARGS = frozenset({
+    "memory_write", "memory_update", "ask_user",
+    "enter_plan_mode", "write_plan", "enter_step",
+    "mark_step_done", "mark_step_blocked", "exit_plan_mode",
+})
+
+# ── Bash / shell tool names (command arg truncation target) ──────────────────
+
+_BASH_TOOLS = frozenset({
+    "bash", "shell", "run_bash", "execute_command", "terminal",
+    "Bash", "run_command", "execute", "cmd", "Run",
+})
+
+
+class ToolResultCompressionMiddleware(AgentMiddleware):
+    """Truncate old tool results and bash command args before every model call.
+
+    Only operates on messages older than `keep_recent` from the end of the
+    message list. Recent messages are never touched so the agent has full
+    verbatim context for its current work.
+
+    Fail-open: any exception passes the original request through unchanged.
+    """
+
+    def __init__(
+        self,
+        keep_recent: int = 20,
+        max_result_chars: int = 1500,
+        max_cmd_chars: int = 600,
+        max_findings_arg_chars: int = 250,
+        min_chars: int = 500,
+    ) -> None:
+        self._keep_recent = keep_recent
+        self._max_result_chars = max_result_chars
+        self._max_cmd_chars = max_cmd_chars
+        self._max_findings_arg_chars = max_findings_arg_chars
+        self._min_chars = min_chars
+
+    def _compress(self, request: ModelRequest) -> ModelRequest:
+        msgs = list(request.messages or [])
+        if not msgs:
+            return request
+
+        # Only touch messages older than keep_recent from the end
+        cutoff = max(0, len(msgs) - self._keep_recent)
+        if cutoff == 0:
+            return request
+
+        changed = False
+        new_msgs = list(msgs)
+
+        for i in range(cutoff):
+            msg = new_msgs[i]
+
+            # ── HumanMessage — NEVER touch ────────────────────────────────────
+            if isinstance(msg, HumanMessage):
+                continue
+
+            # ── SystemMessage — NEVER touch ───────────────────────────────────
+            if isinstance(msg, SystemMessage):
+                continue
+
+            # ── ToolMessage — truncate large results from data tools ──────────
+            if isinstance(msg, ToolMessage):
+                tool_name = getattr(msg, "name", "") or ""
+                if tool_name in _NEVER_TRUNCATE_TOOL_RESULTS:
+                    continue
+                content = msg.content
+                if not isinstance(content, str):
+                    content = str(content) if content is not None else ""
+                if len(content) > self._min_chars:
+                    kept = content[:self._max_result_chars]
+                    overflow = len(content) - self._max_result_chars
+                    suffix = f"\n...(+{overflow} chars truncated)"
+                    new_msgs[i] = ToolMessage(
+                        content=kept + suffix,
+                        tool_call_id=msg.tool_call_id,
+                        name=tool_name,
+                    )
+                    changed = True
+                continue
+
+            # ── AIMessage — truncate bash command args + findings_add desc ────
+            if isinstance(msg, AIMessage):
+                tool_calls = getattr(msg, "tool_calls", None) or []
+                if not tool_calls:
+                    continue
+
+                new_tool_calls = []
+                tc_changed = False
+
+                for tc in tool_calls:
+                    name = tc.get("name", "") or ""
+                    args = dict(tc.get("args") or {})
+
+                    # findings_add: truncate description field only
+                    if name == "findings_add":
+                        desc = str(args.get("description", ""))
+                        if len(desc) > self._max_findings_arg_chars:
+                            args["description"] = (
+                                desc[:self._max_findings_arg_chars]
+                                + "...(recorded in findings store)"
+                            )
+                            tc_changed = True
+                        new_tool_calls.append({**tc, "args": args})
+                        continue
+
+                    # Never bulk-truncate these tools' args
+                    if name in _NEVER_TRUNCATE_ARGS:
+                        new_tool_calls.append(tc)
+                        continue
+
+                    # Bash/shell: truncate command arg specifically
+                    if name in _BASH_TOOLS or name.lower() in {t.lower() for t in _BASH_TOOLS}:
+                        cmd = str(args.get("command", ""))
+                        if len(cmd) > self._max_cmd_chars:
+                            args["command"] = cmd[:self._max_cmd_chars] + "...(truncated)"
+                            tc_changed = True
+                        new_tool_calls.append({**tc, "args": args})
+                        continue
+
+                    # Unknown / other tools: truncate any individual string arg > max_cmd_chars.
+                    # This covers nuclei_scan, http_request, jwt_decode, MCP tools, etc.
+                    # Each arg value is checked independently — only large strings are trimmed.
+                    for k, v in list(args.items()):
+                        if isinstance(v, str) and len(v) > self._max_cmd_chars:
+                            args[k] = v[:self._max_cmd_chars] + "...(truncated)"
+                            tc_changed = True
+
+                    new_tool_calls.append({**tc, "args": args})
+
+                if tc_changed:
+                    # Rebuild AIMessage preserving all original fields
+                    new_msgs[i] = msg.copy(update={"tool_calls": new_tool_calls})
+                    changed = True
+
+        if not changed:
+            return request
+
+        return request.override(messages=new_msgs)
+
+    def wrap_model_call(self, request: ModelRequest, handler: Any) -> ModelResponse:
+        try:
+            return handler(self._compress(request))
+        except Exception:
+            logger.debug(
+                "ToolResultCompressionMiddleware: compression failed, passing through",
+                exc_info=True,
+            )
+            return handler(request)
+
+    async def awrap_model_call(self, request: ModelRequest, handler: Any) -> ModelResponse:
+        try:
+            return await handler(self._compress(request))
+        except Exception:
+            logger.debug(
+                "ToolResultCompressionMiddleware: compression failed, passing through",
+                exc_info=True,
+            )
+            return await handler(request)

--- a/src/rai/sdk/__init__.py
+++ b/src/rai/sdk/__init__.py
@@ -107,6 +107,9 @@ from rai.sdk.middleware import (
     SkillsMiddleware,
     LocalAsyncAgentMiddleware,
     RTKToolMiddleware,
+    MessageCompressionMiddleware,
+    ToolResultCompressionMiddleware,
+    LoopDetectionMiddleware,
 )
 
 # ---- Tools (top-level getters) ---------------------------------------------
@@ -187,6 +190,9 @@ __all__ = [
     "LocalAsyncAgentMiddleware",
     "RAIPromptCachingMiddleware",
     "RTKToolMiddleware",
+    "MessageCompressionMiddleware",
+    "ToolResultCompressionMiddleware",
+    "LoopDetectionMiddleware",
     # Model SDK
     "build_model",
     "ModelConfig",

--- a/src/rai/sdk/middleware/__init__.py
+++ b/src/rai/sdk/middleware/__init__.py
@@ -15,6 +15,9 @@ from rai.sdk.middleware.middleware import (  # noqa: F401
     SkillsMiddleware,
     LocalAsyncAgentMiddleware,
     RTKToolMiddleware,
+    MessageCompressionMiddleware,
+    ToolResultCompressionMiddleware,
+    LoopDetectionMiddleware,
 )
 
 __all__ = [
@@ -32,4 +35,7 @@ __all__ = [
     "SkillsMiddleware",
     "LocalAsyncAgentMiddleware",
     "RTKToolMiddleware",
+    "MessageCompressionMiddleware",
+    "ToolResultCompressionMiddleware",
+    "LoopDetectionMiddleware",
 ]

--- a/src/rai/sdk/middleware/middleware.py
+++ b/src/rai/sdk/middleware/middleware.py
@@ -14,6 +14,9 @@ from rai.middleware.model_override import ModelOverrideMiddleware
 from rai.middleware.opplan import OPPLANMiddleware
 from rai.middleware.ratelimit import RateLimitMiddleware
 from rai.middleware.sanitizer import EmptyContentSanitizerMiddleware
+from rai.middleware.compression import MessageCompressionMiddleware
+from rai.middleware.tool_compaction import ToolResultCompressionMiddleware
+from rai.middleware.loop_detection import LoopDetectionMiddleware
 
 try:
     from rai.middleware.prompt_cache import RAIPromptCachingMiddleware
@@ -41,4 +44,7 @@ __all__ = [
     "SkillsMiddleware",
     "LocalAsyncAgentMiddleware",
     "RTKToolMiddleware",
+    "MessageCompressionMiddleware",
+    "ToolResultCompressionMiddleware",
+    "LoopDetectionMiddleware",
 ]

--- a/src/rai/tui/app.py
+++ b/src/rai/tui/app.py
@@ -288,7 +288,7 @@ class RaiHttpTUIApp(App):
         except Exception:
             pass
         try:
-            history = await self._client.threads.history(thread_id, limit=500)
+            history = await self._client.threads.history_tail(thread_id, limit=500)
             messages = history.get("messages", [])
             total = history.get("total", len(messages))
             container = self.query_one("#messages", Container)
@@ -308,8 +308,14 @@ class RaiHttpTUIApp(App):
 
                 if msg_type == "human":
                     c = str(content)
-                    # Skip: background-agent watcher injections and /compact invocations
-                    if not c or c.startswith("[Background agent") or c.strip() == "/compact":
+                    # Skip: injected control messages — never show to user
+                    if (
+                        not c
+                        or c.startswith("[Background agent")
+                        or c.strip() == "/compact"
+                        or c.strip().startswith("<system-reminder>")
+                        or "<system-reminder>" in c
+                    ):
                         continue
                     await container.mount(UserMsg(c))
 


### PR DESCRIPTION
## Summary

- **LoopDetectionMiddleware** — blocks duplicate tool calls, returns cached result with ⚠ warning (stops 50× loop degenerate under context pressure)
- **ToolResultCompressionMiddleware** — layer-2 compression, truncates old bash/grep/file results to 1500 chars, bash args to 600 chars; never touches HumanMessages, plan tools, findings, memory
- **Token cost fix** — `_char_estimate()` now counts `tool_call` args in compression budget (was bypassing 75k limit causing 390-msg sessions at 119k chars)
- **compact_model** — summarization uses a configurable cheap model; saves $2–5 per long session
- **Plan mode** — `exit_plan_mode` strips 5,700-char step digest; `list_plan_steps` compact for done steps
- **TUI** — thread resume loads last 50 messages (not first 50); filters `<system-reminder>` from history display
- **Debug** — `RequestInspectorMiddleware` for MITM proxy inspection (inert unless `RAI_INSPECT=1`)
- Version bumped to `2.0.1` in `pyproject.toml` and `__init__.py`

## Build verification

Local `uv build` confirmed: 209 files, 183 Python modules in wheel. `pip install revolt-rai` / `uv tool install revolt-rai` will work correctly.

## Test plan

- [x] `uv tool install revolt-rai` installs cleanly
- [x] `rai chat` starts and connects to HTTP server
- [x] Long session: verify token counts stay bounded (check `~/.rai/debug/model-calls.jsonl` with `RAI_DEBUG_LOG_CALLS=1`)
- [x] Loop detection: verify duplicate bash calls return cached result with ⚠ warning
- [x] Plan mode: verify `exit_plan_mode` does not repeat step digest in output